### PR TITLE
Add support for all FERC forms

### DIFF
--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 
 from ferc_xbrl_extractor import helpers, xbrl
 from ferc_xbrl_extractor.helpers import get_logger
-from ferc_xbrl_extractor.instance import Instance
+from ferc_xbrl_extractor.instance import InstanceBuilder
 
 DEFAULT_TAXONOMY = "https://eCollection.ferc.gov/taxonomy/form1/2022-01-01/form/form1/form-1_2022-01-01.xsd"
 
@@ -93,7 +93,7 @@ def get_instances(instance_path: Path):
         instances = instance_path.iterdir()
 
     return [
-        Instance(str(instance), instance.name.rstrip(instance.suffix))
+        InstanceBuilder(str(instance), instance.name.rstrip(instance.suffix))
         for instance in sorted(instances)
         if instance.suffix in allowable_suffixes
     ]

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -117,7 +117,7 @@ CONVERT_DTYPES: Dict[str, Callable] = {
 Map callables to schema field type to convert parsed values (Data Package `field.type`).
 """
 
-TABLE_NAME_PATTERN = re.compile("(\d{3}[a-z]?) - Schedule - (.*)")  # noqa: W605, FS003
+TABLE_NAME_PATTERN = re.compile("(.+) - Schedule - (.*)")  # noqa: W605, FS003
 """
 Simple regex pattern used to clean up table names.
 """

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -8,7 +8,7 @@ import stringcase
 from pydantic import BaseModel
 
 from .helpers import get_logger
-from .instance import Context, Fact
+from .instance import Instance
 from .taxonomy import Concept, LinkRole, Taxonomy
 
 
@@ -360,23 +360,15 @@ class FactTable(object):
         self.instant = period_type == "instant"
         self.logger = get_logger(__name__)
 
-    def construct_dataframe(
-        self, facts: Dict[str, Fact], contexts: Dict[str, Context], filing_name: str
-    ) -> pd.DataFrame:
+    def construct_dataframe(self, instance: Instance) -> pd.DataFrame:
         """
-        Construct dataframe from facts and contexts extracted from filing.
+        Construct dataframe from a parsed XBRL instance.
 
         Args:
-            facts: Dictionary mapping context id's to facts.
-            contexts: Dictionary mapping context id's to contexts.
-            filing_name: Name of current filing.
+            instance: Parsed XBRL instance used to construct dataframe.
         """
         # Filter contexts to only those relevant to table
-        contexts = {
-            c_id: context
-            for c_id, context in contexts.items()
-            if context.check_dimensions(self.axes)
-        }
+        contexts = instance.get_facts(self.instant, self.axes)
 
         # Get the maximum number of rows that could be in table and allocate space
         max_len = len(contexts)
@@ -389,17 +381,17 @@ class FactTable(object):
 
         # Loop through contexts and get facts in each context
         # Each context corresponds to one unique row
-        for i, (c_id, context) in enumerate(contexts.items()):
+        for i, (context, facts) in enumerate(contexts.items()):
             if self.instant != context.period.instant:
                 continue
 
             # Construct dictionary to represent row which corresponds to current context
-            row = {fact.name: fact.value for fact in facts[c_id] if fact.name in df}
+            row = {fact.name: fact.value for fact in facts if fact.name in df}
 
             # If row is empty skip
             if row:
                 # Use context to create primary key for row and add to dictionary
-                row.update(contexts[c_id].as_primary_key(filing_name))
+                row.update(context.as_primary_key(instance.filing_name))
 
                 # Loop through each field in row and add to appropriate column
                 for key, val in row.items():

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -10,12 +10,12 @@ import sqlalchemy as sa
 
 from .datapackage import Datapackage
 from .helpers import get_logger
-from .instance import Instance
+from .instance import InstanceBuilder
 from .taxonomy import Taxonomy
 
 
 def extract(
-    instances: List[Instance],
+    instances: List[InstanceBuilder],
     engine: sa.engine.Engine,
     taxonomy: str,
     batch_size: Optional[int] = None,
@@ -69,7 +69,7 @@ def extract(
 
 
 def process_batch(
-    instances: Iterable[Instance],
+    instances: Iterable[InstanceBuilder],
     db_path: str,
     taxonomy: str,
     save_metadata: bool = False,
@@ -104,7 +104,7 @@ def process_batch(
 
 
 def process_instance(
-    instance: Instance,
+    instance_parser: InstanceBuilder,
     db_path: str,
     taxonomy: str,
     save_metadata: bool = False,
@@ -119,15 +119,15 @@ def process_instance(
         save_metadata: Save XBRL references in JSON file.
     """
     logger = get_logger(__name__)
-    contexts, facts, filing_name = instance.parse()
+    instance = instance_parser.parse()
 
     tables = get_fact_tables(taxonomy, db_path, save_metadata)
 
-    logger.info(f"Extracting {filing_name}")
+    logger.info(f"Extracting {instance.filing_name}")
 
     dfs = {}
     for key, table in tables.items():
-        dfs[key] = table.construct_dataframe(facts, contexts, filing_name)
+        dfs[key] = table.construct_dataframe(instance)
 
     return dfs
 


### PR DESCRIPTION
This pull request adds support for selecting any Ferc form taxonomy for constructing the output database. It also includes some minor refactoring of how XBRL instances are parsed. Now it will return a class which wraps the parsed `Facts` and `Contexts`, rather than returning them directly.