### PR TITLE
Determine mapping between FERC 1 DBF `respondent_id` and XBRL `entity_id`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - jupyterlab>=3.2,<4
   - nbconvert>=6,<7  # Used to clear notebook outputs in pre-commit hooks
   - scipy
+  - fuzzywuzzy
 
   # XBRL parsing library
   - pip:

--- a/notebooks/respondent_id_map.ipynb
+++ b/notebooks/respondent_id_map.ipynb
@@ -33,7 +33,8 @@
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
-    "from sqlalchemy import create_engine"
+    "import sqlalchemy as sa\n",
+    "from fuzzywuzzy import fuzz"
    ]
   },
   {
@@ -51,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "engine = create_engine(\"sqlite:///ferc1.sqlite\")\n",
+    "engine = sa.create_engine(\"sqlite:///ferc1.sqlite\")\n",
     "\n",
     "# Select RespondentLegalName as well for convenience\n",
     "id_table = pd.read_sql(\n",
@@ -126,9 +127,150 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "126d881a-2b10-4128-9f2d-6f8a23b80a6b",
+   "metadata": {},
+   "source": [
+    "## Supplement missing `respondent_id`'s with string matching"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4be6063-3e9b-45ad-8e7a-ccc5723d31c0",
+   "id": "6b69d2e0-c65c-489f-9c96-03124ce830ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ferc1_db_path = \"/home/zach/catalyst/workspace/sqlite/ferc1.sqlite\"\n",
+    "pudl_engine = sa.create_engine(\"sqlite:///\" + ferc1_db_path)\n",
+    "inspector = sa.inspect(pudl_engine)\n",
+    "\n",
+    "df = pd.DataFrame(columns=[\"report_year\", \"respondent_id\"])\n",
+    "for tbl in inspector.get_table_names():\n",
+    "    cols = [col['name'] for col in inspector.get_columns(tbl)]\n",
+    "    if (\"report_year\" in cols) & (\"respondent_id\" in cols):\n",
+    "        df = pd.concat([df, pd.read_sql(f\"SELECT DISTINCT report_year, respondent_id FROM {tbl}\", pudl_engine)])\n",
+    "\n",
+    "df = df.drop_duplicates()\n",
+    "\n",
+    "# Find respondent_id's that don't exist in migrated XBRL data\n",
+    "missing_ids = set(df[\"respondent_id\"]) - set(map_table[\"respondent_id\"])\n",
+    "print(len(missing_ids))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fabe1f45-9113-4d50-af29-a76de2788f0c",
+   "metadata": {},
+   "source": [
+    "There's 116 ID's that are missing in the XBRL data, which can certainly be mapped manually, but it might be easier to try and use some fuzzy string matching to help out. There's a table provided by FERC that maps between the new `entity_id`'s and respondent names, which can be downloaded [here](https://www.ferc.gov/media/ferc-cid-listing). This will be used to do the string matching. Many of the missing ID's also don't appear at all in newer years of data, and quite possibly don't exist in FERC's new Company Identifier system, so it will likely only be a subset of the missing ID's for which there is a match at all."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd3905c4-c19b-4635-880d-b5f7c250a121",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load CID lookup table\n",
+    "lookup_table = pd.read_excel(\"FERC_CID_Listing_6-6-2022.xlsx\", skiprows=2)\n",
+    "lookup_table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8723a5cf-bb0c-4f4d-bec3-84e6e915726a",
+   "metadata": {},
+   "source": [
+    "Find the closest name in this table to each missing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e49096a0-79b7-45ff-b95d-2326e4082221",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read respondent ID table from historical data for respondent names\n",
+    "respondent_names = pd.read_sql(\"SELECT respondent_id, respondent_name FROM f1_respondent_id\", pudl_engine)\n",
+    "respondent_names = respondent_names.set_index(\"respondent_id\")\n",
+    "\n",
+    "# Loop through missing IDs and do a fuzzy string match between respondent names and CID lookup table names\n",
+    "new_matches_df = {\"entity_id\": [], \"RespondentLegalName\": [], \"respondent_id\": [], \"old_name\": []}\n",
+    "for r_id in missing_ids:\n",
+    "    name = respondent_names[\"respondent_name\"][r_id]\n",
+    "    matches = lookup_table[\"Organization Name\"].apply(fuzz.ratio, args=(name,))\n",
+    "    \n",
+    "    if matches.max() > 85:\n",
+    "        # Add row to new dataframe\n",
+    "        new_matches_df[\"entity_id\"].append(lookup_table[\"CID\"][matches.idxmax()])\n",
+    "        new_matches_df[\"respondent_id\"].append(r_id)\n",
+    "        new_matches_df[\"RespondentLegalName\"].append(lookup_table[\"Organization Name\"][matches.idxmax()])\n",
+    "        new_matches_df[\"old_name\"].append(name)\n",
+    "\n",
+    "        \n",
+    "        # Print matches for visual inspection\n",
+    "        print(f\"{name} -> {lookup_table['Organization Name'][matches.idxmax()]}\")\n",
+    "\n",
+    "new_matches_df = pd.DataFrame(new_matches_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ec00538-bea3-49b5-93d6-107b9f6dd88b",
+   "metadata": {},
+   "source": [
+    "I've limited the matches to only those with a fuzzy match ratio greater than 85. This is somewhat arbitrary, but I settled on this by lowering it until all additional matches found were clearly false positives. There are clearly several false positives that need to be manually removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7a82fa9-9c9f-425e-9f4a-efb8aa161865",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# False positives from visual inspection\n",
+    "false_positives = [\n",
+    "    \"IES Utilities Inc.\",\n",
+    "    \"Ocean State Power\",\n",
+    "    \"TXE Electric Company\",\n",
+    "    \"Bridger Valley Electric Association, Inc.\",\n",
+    "    \"Flowell Electric Association, Inc.\",\n",
+    "]\n",
+    "\n",
+    "# Drop false positives then get rid of old_name column\n",
+    "new_matches_df = new_matches_df.drop(\n",
+    "    new_matches_df[new_matches_df[\"old_name\"].isin(false_positives)].index\n",
+    ")\n",
+    "new_matches_df = new_matches_df.drop(\"old_name\", axis=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24a40658-92cd-43c1-9bc5-f9ba5233ac62",
+   "metadata": {},
+   "source": [
+    "Now these new matches can be added to the mapping table and the CSV can be rewritten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "361699bf-4b79-4345-a6bf-af467fa2256b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map_table = pd.concat([map_table, new_matches_df])\n",
+    "map_table.to_csv(\"respondent_map.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7621359f-521b-483e-9b7e-fc3247a03955",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -150,7 +292,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/notebooks/respondent_id_map.ipynb
+++ b/notebooks/respondent_id_map.ipynb
@@ -5,12 +5,28 @@
    "id": "d9d7f81f-e654-46bf-b9da-020066c31888",
    "metadata": {},
    "source": [
-    "# Notebook to map respondent ID to entity ID"
+    "# Notebook to map respondent ID to entity ID\n",
+    "\n",
+    "This notebook provides a simple \"first draft\" of mapping of `respondent_id`'s from the historical\n",
+    "DBF based FERC data to `entity_id`'s in the new XBRL based data. To do this, this notebook\n",
+    "will use the years of data that FERC has migrated to the new XBRL format. Each filing they\n",
+    "have migrated contains the `respondent_id` in the file name, and the `entity_id` embedded in\n",
+    "the filings.\n",
+    "\n",
+    "The first step is to extract the migrated filings to a SQLite database to make the entity ID's\n",
+    "accessible. These filings can be downloaded [here](https://ferc.gov/filing-forms/eforms-refresh/migrated-data-downloads).\n",
+    "There's not data for every filer included in each year of data, so using the entire set of years will\n",
+    "provide the best results. To create the SQLite database, extract the downloaded zip files to a single\n",
+    "directory, then use the FERC XBRL extractor tool with the following command:\n",
+    "\n",
+    "```\n",
+    "xbrl_extract {path_to_filing_directory} ferc1.sqlite\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "61d162b1-0ef8-4387-b128-977574b48e6e",
    "metadata": {},
    "outputs": [],
@@ -21,153 +37,68 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "410e7814-85af-42dc-bf26-e0189fde3d83",
+   "metadata": {},
+   "source": [
+    "The only data needed to perform the mapping are the `filing_name`, and `entity_id` columns from the `identificiation_001_duration` table."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "8d4716ae-7534-4758-be03-cfad971653de",
    "metadata": {},
    "outputs": [],
    "source": [
     "engine = create_engine(\"sqlite:///ferc1.sqlite\")\n",
     "\n",
+    "# Select RespondentLegalName as well for convenience\n",
     "id_table = pd.read_sql(\n",
-    "    \"SELECT filing_name, entity_id FROM identification_001_duration\",\n",
+    "    \"SELECT filing_name, entity_id, RespondentLegalName FROM identification_001_duration\",\n",
     "    engine,\n",
     "    parse_dates=[\"start_date\", \"end_date\"]\n",
     ")"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "7b1b188f-fb30-4df3-8f25-1f299029838c",
+   "cell_type": "markdown",
+   "id": "09124f7d-37af-491a-92ef-a2c37f9dcaf2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>filing_name</th>\n",
-       "      <th>entity_id</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>AepAppalachianTransmissionCompanyInc-436-2011Q3F1</td>\n",
-       "      <td>R001436</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>AepAppalachianTransmissionCompanyInc-436-2011Q4F1</td>\n",
-       "      <td>R001436</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>AepGeneratingCompany-1-2011Q3F1</td>\n",
-       "      <td>C003184</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>AepGeneratingCompany-1-2011Q4F1</td>\n",
-       "      <td>C003184</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>AepIndianaMichiganTransmissionCompanyInc-440-2...</td>\n",
-       "      <td>R001440</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1257</th>\n",
-       "      <td>WolverinePowerSupplyCooperativeInc-227-2021Q1F1</td>\n",
-       "      <td>C001188</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1258</th>\n",
-       "      <td>WolverinePowerSupplyCooperativeInc-227-2021Q2F1</td>\n",
-       "      <td>C001188</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1259</th>\n",
-       "      <td>YankeeAtomicElectricCompany-198-2020Q4F1</td>\n",
-       "      <td>C002116</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1260</th>\n",
-       "      <td>YankeeAtomicElectricCompany-198-2021Q1F1</td>\n",
-       "      <td>C002116</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1261</th>\n",
-       "      <td>YankeeAtomicElectricCompany-198-2021Q2F1</td>\n",
-       "      <td>C002116</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>1262 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                            filing_name entity_id\n",
-       "0     AepAppalachianTransmissionCompanyInc-436-2011Q3F1   R001436\n",
-       "1     AepAppalachianTransmissionCompanyInc-436-2011Q4F1   R001436\n",
-       "2                       AepGeneratingCompany-1-2011Q3F1   C003184\n",
-       "3                       AepGeneratingCompany-1-2011Q4F1   C003184\n",
-       "4     AepIndianaMichiganTransmissionCompanyInc-440-2...   R001440\n",
-       "...                                                 ...       ...\n",
-       "1257    WolverinePowerSupplyCooperativeInc-227-2021Q1F1   C001188\n",
-       "1258    WolverinePowerSupplyCooperativeInc-227-2021Q2F1   C001188\n",
-       "1259           YankeeAtomicElectricCompany-198-2020Q4F1   C002116\n",
-       "1260           YankeeAtomicElectricCompany-198-2021Q1F1   C002116\n",
-       "1261           YankeeAtomicElectricCompany-198-2021Q2F1   C002116\n",
-       "\n",
-       "[1262 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "id_table"
+    "The `respondent_id` is embedded in each filing name with the format `{UtilityName}-{respondent_id}-{year}{quarter}{form_number}`.\n",
+    "The first step is extract that ID, then drop duplicate pairs (same pairs will exist for different years)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7a139a94-938c-4c85-957f-6e8244f6dc91",
    "metadata": {},
    "outputs": [],
    "source": [
-    "id_table[\"respondent_id\"] = id_table[\"filing_name\"].str.extract(r'.+-(\\d+)-.+')\n",
-    "map_table = id_table.drop(\"filing_name\", axis=1).drop_duplicates()"
+    "id_table[\"respondent_id\"] = pd.to_numeric(\n",
+    "    id_table[\"filing_name\"].str.extract(r'.+-(\\d+)-.+').loc[:,0]\n",
+    ")\n",
+    "map_table = (\n",
+    "    id_table.drop(\"filing_name\", axis=1)\n",
+    "    .drop_duplicates(subset=[\"entity_id\", \"respondent_id\"])\n",
+    "    .convert_dtypes()\n",
+    "    .sort_values(by=[\"respondent_id\"])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fccd2d49-25b0-4e75-89c1-c9ec2f1aa069",
+   "metadata": {},
+   "source": [
+    "Save the mapping to a CSV file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "d08ed2a1-950c-460f-ace0-0b2877b8f311",
    "metadata": {},
    "outputs": [],
@@ -176,40 +107,28 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 22,
-   "id": "7ede8dd1-4f7c-49b3-b0ad-a925ce650a3a",
+   "cell_type": "markdown",
+   "id": "bf7d723c-635f-4d11-af6b-8f4956d89352",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "854     C000319\n",
-       "1231    C001252\n",
-       "Name: entity_id, dtype: object"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "map_table[\"entity_id\"][map_table[\"entity_id\"].duplicated()]"
+    "Check for any `entity_id`'s that map to multiple `respondent_id`'s. These will need to be analyzed\n",
+    "further to identify if they are mistakes or if something else is happening."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45ab7fbd-1d4c-46aa-8247-9e7105819561",
+   "id": "26160cc7-d6e1-4878-8338-f51299c0568e",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "map_table.loc[map_table[\"entity_id\"].duplicated(), :]"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26160cc7-d6e1-4878-8338-f51299c0568e",
+   "id": "f4be6063-3e9b-45ad-8e7a-ccc5723d31c0",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -231,7 +150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/respondent_id_map.ipynb
+++ b/notebooks/respondent_id_map.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d9d7f81f-e654-46bf-b9da-020066c31888",
+   "metadata": {},
+   "source": [
+    "# Notebook to map respondent ID to entity ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "61d162b1-0ef8-4387-b128-977574b48e6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sqlalchemy import create_engine"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8d4716ae-7534-4758-be03-cfad971653de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "engine = create_engine(\"sqlite:///ferc1.sqlite\")\n",
+    "\n",
+    "id_table = pd.read_sql(\n",
+    "    \"SELECT filing_name, entity_id FROM identification_001_duration\",\n",
+    "    engine,\n",
+    "    parse_dates=[\"start_date\", \"end_date\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7b1b188f-fb30-4df3-8f25-1f299029838c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>filing_name</th>\n",
+       "      <th>entity_id</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>AepAppalachianTransmissionCompanyInc-436-2011Q3F1</td>\n",
+       "      <td>R001436</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>AepAppalachianTransmissionCompanyInc-436-2011Q4F1</td>\n",
+       "      <td>R001436</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>AepGeneratingCompany-1-2011Q3F1</td>\n",
+       "      <td>C003184</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>AepGeneratingCompany-1-2011Q4F1</td>\n",
+       "      <td>C003184</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>AepIndianaMichiganTransmissionCompanyInc-440-2...</td>\n",
+       "      <td>R001440</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1257</th>\n",
+       "      <td>WolverinePowerSupplyCooperativeInc-227-2021Q1F1</td>\n",
+       "      <td>C001188</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1258</th>\n",
+       "      <td>WolverinePowerSupplyCooperativeInc-227-2021Q2F1</td>\n",
+       "      <td>C001188</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1259</th>\n",
+       "      <td>YankeeAtomicElectricCompany-198-2020Q4F1</td>\n",
+       "      <td>C002116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1260</th>\n",
+       "      <td>YankeeAtomicElectricCompany-198-2021Q1F1</td>\n",
+       "      <td>C002116</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1261</th>\n",
+       "      <td>YankeeAtomicElectricCompany-198-2021Q2F1</td>\n",
+       "      <td>C002116</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>1262 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                            filing_name entity_id\n",
+       "0     AepAppalachianTransmissionCompanyInc-436-2011Q3F1   R001436\n",
+       "1     AepAppalachianTransmissionCompanyInc-436-2011Q4F1   R001436\n",
+       "2                       AepGeneratingCompany-1-2011Q3F1   C003184\n",
+       "3                       AepGeneratingCompany-1-2011Q4F1   C003184\n",
+       "4     AepIndianaMichiganTransmissionCompanyInc-440-2...   R001440\n",
+       "...                                                 ...       ...\n",
+       "1257    WolverinePowerSupplyCooperativeInc-227-2021Q1F1   C001188\n",
+       "1258    WolverinePowerSupplyCooperativeInc-227-2021Q2F1   C001188\n",
+       "1259           YankeeAtomicElectricCompany-198-2020Q4F1   C002116\n",
+       "1260           YankeeAtomicElectricCompany-198-2021Q1F1   C002116\n",
+       "1261           YankeeAtomicElectricCompany-198-2021Q2F1   C002116\n",
+       "\n",
+       "[1262 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "id_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "7a139a94-938c-4c85-957f-6e8244f6dc91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "id_table[\"respondent_id\"] = id_table[\"filing_name\"].str.extract(r'.+-(\\d+)-.+')\n",
+    "map_table = id_table.drop(\"filing_name\", axis=1).drop_duplicates()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "d08ed2a1-950c-460f-ace0-0b2877b8f311",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map_table.to_csv(\"respondent_map.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "7ede8dd1-4f7c-49b3-b0ad-a925ce650a3a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "854     C000319\n",
+       "1231    C001252\n",
+       "Name: entity_id, dtype: object"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "map_table[\"entity_id\"][map_table[\"entity_id\"].duplicated()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45ab7fbd-1d4c-46aa-8247-9e7105819561",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26160cc7-d6e1-4878-8338-f51299c0568e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/respondent_id_map.ipynb
+++ b/notebooks/respondent_id_map.ipynb
@@ -113,7 +113,7 @@
    "metadata": {},
    "source": [
     "Check for any `entity_id`'s that map to multiple `respondent_id`'s. These will need to be analyzed\n",
-    "further to identify if they are mistakes or if something else is happening."
+    "further to identify if there are any mistakes."
    ]
   },
   {
@@ -131,7 +131,8 @@
    "id": "126d881a-2b10-4128-9f2d-6f8a23b80a6b",
    "metadata": {},
    "source": [
-    "## Supplement missing `respondent_id`'s with string matching"
+    "## Supplement missing `respondent_id`'s with string matching\n",
+    "There are 257 unique `respondent_id -> entity_id` pairs. It's hard to say exactly how many there *should* be, because the set of unique `respondent_id`'s varies a fair amount from year to year. FERC has indicated that not all filings are included in the migrated data, so it is likely that there are missing `respondent_id`'s. To attempt to supplement this mapping, we can try to use the respondent legal names to try and find missing pairs. First, get all `respondent_id`'s from the raw DBF database produced by `ferc1_to_sqlite` in PUDL."
    ]
   },
   {
@@ -145,6 +146,7 @@
     "pudl_engine = sa.create_engine(\"sqlite:///\" + ferc1_db_path)\n",
     "inspector = sa.inspect(pudl_engine)\n",
     "\n",
+    "# Get all respondent_id's by report_year\n",
     "df = pd.DataFrame(columns=[\"report_year\", \"respondent_id\"])\n",
     "for tbl in inspector.get_table_names():\n",
     "    cols = [col['name'] for col in inspector.get_columns(tbl)]\n",
@@ -163,7 +165,7 @@
    "id": "fabe1f45-9113-4d50-af29-a76de2788f0c",
    "metadata": {},
    "source": [
-    "There's 116 ID's that are missing in the XBRL data, which can certainly be mapped manually, but it might be easier to try and use some fuzzy string matching to help out. There's a table provided by FERC that maps between the new `entity_id`'s and respondent names, which can be downloaded [here](https://www.ferc.gov/media/ferc-cid-listing). This will be used to do the string matching. Many of the missing ID's also don't appear at all in newer years of data, and quite possibly don't exist in FERC's new Company Identifier system, so it will likely only be a subset of the missing ID's for which there is a match at all."
+    "There are 116 ID's that are missing in the XBRL data, which can certainly be mapped manually, but it might be easier to try and use some fuzzy string matching to help out. There's a table provided by FERC that maps between the new `entity_id`'s and respondent names, which can be downloaded [here](https://www.ferc.gov/media/ferc-cid-listing). This will be used to do the string matching. Many of the missing ID's also don't appear at all in newer years of data, and quite possibly don't exist in FERC's new Company Identifier system, so it will likely only be a subset of the missing ID's for which there is a match at all."
    ]
   },
   {
@@ -183,7 +185,7 @@
    "id": "8723a5cf-bb0c-4f4d-bec3-84e6e915726a",
    "metadata": {},
    "source": [
-    "Find the closest name in this table to each missing"
+    "For each missing `respondent_id` find the respondent name that most closely matches the name listed in the DBF database."
    ]
   },
   {
@@ -214,7 +216,7 @@
     "        # Print matches for visual inspection\n",
     "        print(f\"{name} -> {lookup_table['Organization Name'][matches.idxmax()]}\")\n",
     "\n",
-    "new_matches_df = pd.DataFrame(new_matches_df)"
+    "new_matches_df = pd.DataFrame(new_matches_df).set_index(\"old_name\")"
    ]
   },
   {
@@ -235,11 +237,13 @@
     "# False positives from visual inspection\n",
     "false_positives = [\n",
     "    \"IES Utilities Inc.\",\n",
-    "    \"Ocean State Power\",\n",
     "    \"TXE Electric Company\",\n",
     "    \"Bridger Valley Electric Association, Inc.\",\n",
     "    \"Flowell Electric Association, Inc.\",\n",
     "]\n",
+    "\n",
+    "# The top match for 'Ocean State Power' was 'Ocean State Power II', so I'll manually map this to 'Ocean State Power LLC'\n",
+    "new_matches_df.loc[\"Ocean State Power\"] = {\"RespondentLegalName\": \"Ocean State Power LLC\", \"entity_id\": \"C001906\", \"respondent_id\": 124\"}\n",
     "\n",
     "# Drop false positives then get rid of old_name column\n",
     "new_matches_df = new_matches_df.drop(\n",

--- a/notebooks/respondent_map.csv
+++ b/notebooks/respondent_map.csv
@@ -249,7 +249,7 @@ C010143,LS Power Grid New York Corporation I,542
 C001173,Hardee Power Partners Limited,64
 C011397,Hawaiian Electric Company,65
 C004384,Nevada Sun-Peak Limited Partnership,109
-C001907,Ocean State Power II,125
+C001906,Ocean State Power LLC,124
 C000415,DTE Electric Company,173
 C008784,"York Haven Power Company, LLC",199
 C011542,"East Texas Electric Cooperative, Inc.",203

--- a/notebooks/respondent_map.csv
+++ b/notebooks/respondent_map.csv
@@ -246,3 +246,39 @@ C005424,"NextEra Energy Transmission MidAtlantic Indiana, Inc.",539
 C010446,"Wilderness Line Holdings, LLC",540
 C010432,"McKenzie Electric Cooperative, Inc.",541
 C010143,LS Power Grid New York Corporation I,542
+C001173,Hardee Power Partners Limited,64
+C011397,Hawaiian Electric Company,65
+C004384,Nevada Sun-Peak Limited Partnership,109
+C001907,Ocean State Power II,125
+C000415,DTE Electric Company,173
+C008784,"York Haven Power Company, LLC",199
+C011542,"East Texas Electric Cooperative, Inc.",203
+C011423,"Midwest Energy, Inc",213
+C002245,Pacific Northwest Generating Cooperative,222
+C003259,"Valley Electric Association, Inc.",225
+C002111,California Power Exchange Corporation,240
+C003372,Wells Rural Electric Co,264
+C001197,PSEG Nuclear LLC,271
+C001195,PSEG Energy Resources & Trade LLC,272
+C002101,"Michigan Electric Transmission Company, LLC",273
+C002446,International Transmission Company,278
+C002101,"Michigan Electric Transmission Company, LLC",280
+C002101,"Michigan Electric Transmission Company, LLC",291
+C001173,Hardee Power Partners Limited,64
+C011397,Hawaiian Electric Company,65
+C004384,Nevada Sun-Peak Limited Partnership,109
+C001907,Ocean State Power II,125
+C000415,DTE Electric Company,173
+C008784,"York Haven Power Company, LLC",199
+C011542,"East Texas Electric Cooperative, Inc.",203
+C011423,"Midwest Energy, Inc",213
+C002245,Pacific Northwest Generating Cooperative,222
+C003259,"Valley Electric Association, Inc.",225
+C002111,California Power Exchange Corporation,240
+C003372,Wells Rural Electric Co,264
+C001197,PSEG Nuclear LLC,271
+C001195,PSEG Energy Resources & Trade LLC,272
+C002101,"Michigan Electric Transmission Company, LLC",273
+C002446,International Transmission Company,278
+C002101,"Michigan Electric Transmission Company, LLC",280
+C002101,"Michigan Electric Transmission Company, LLC",291

--- a/notebooks/respondent_map.csv
+++ b/notebooks/respondent_map.csv
@@ -1,0 +1,248 @@
+entity_id,RespondentLegalName,respondent_id
+C003184,AEP Generating Company,1
+C001552,ALABAMA POWER COMPANY,2
+R001003,Alaska Electric Light and Power Company,3
+C003448,Alcoa Power Generating Inc.,4
+C000911,THE ALLEGHENY GENERATING COMPANY,5
+C000530,Appalachian Power Company,6
+C001436,Arizona Public Service Company,7
+C000776,"Entergy Arkansas, LLC",8
+C001466,Atlantic City Electric Company,9
+C001111,Baltimore Gas and Electric Company,10
+C000120,Emera Maine,11
+C001421,"Black Hills Power, Inc.",12
+C000135,"Duke Energy Progress, LLC",17
+R001018,Catalyst Old River Hydroelectric Limited Partnership,18
+C001025,CENTRAL HUDSON GAS & ELECTRIC CORPORATION,19
+C000447,Cleco Power LLC,22
+C000615,Central Maine Power Company,23
+C000528,AEP Texas Central Company,24
+R001025,Central Vermont Public Service Corporation,25
+C000292,"Duke Energy Ohio, Inc.",27
+C000314,"Cleveland Electric Illuminating Company, The",30
+R001031,Columbus Southern Power Company,31
+C000199,Commonwealth Edison Company,32
+R001033,"Commonwealth Edison Company of Indiana, Inc.",33
+C001248,UNITIL Power Corp.,35
+C000134,"Consolidated Edison Company of New York, Inc.",36
+C002115,Connecticut Yankee Atomic Power Company,38
+C001016,"Connecticut Light and Power Company, The",39
+C001731,Consolidated Water Power Company,40
+C000191,Consumers Energy Company,41
+C000602,The Dayton Power and Light Company,42
+C001465,Delmarva Power & Light Company,43
+C000415,DTE Electric Company,44
+C000290,"Duke Energy Carolinas, LLC",45
+C001346,Duquesne Light Company,46
+C000465,El Paso Electric Company,49
+C002079,"Electric Energy, Inc.",50
+C001130,The Empire District Electric Company,51
+R001052,"Entergy Power, LLC",52
+C001221,Fitchburg Gas and Electric Light Company,54
+C000136,"Duke Energy Florida, LLC",55
+C001030,Florida Power & Light Company,56
+C001553,Georgia Power Company,57
+C001298,"Golden Spread Electric Cooperative, Inc.",58
+C001307,Liberty Utilities (Granite State Electric) Corp.,59
+C001745,Green Mountain Power Corp,61
+C001554,Gulf Power Company,62
+C000847,"Entergy Gulf States Louisiana, L.L.C.",63
+C002012,"CenterPoint Energy Houston Electric, LLC",68
+C000620,Idaho Power Company,70
+R001072,Indiana-Kentucky Electric Corporation,72
+C000532,Indiana Michigan Power Company,73
+C001315,Indianapolis Power & Light Company,74
+C000312,Jersey Central Power & Light Company,77
+C001181,"Evergy Metro, Inc.",79
+R001080,"Evergy Kansas South, Inc.",80
+C000533,Kentucky Power Company,81
+C000555,Kentucky Utilities Company,82
+C000534,Kingsport Power Company,83
+C001153,Lockhart Power Company,84
+C001322,National Grid Generation LLC,85
+R001087,EL Investment Company,87
+C000553,Louisville Gas and Electric Company,88
+C002498,Madison Gas and Electric Company,89
+C000616,"Maine Electric Power Company, Inc.",90
+C001643,Maine Public Service Company,91
+C003483,Maine Yankee Atomic Power Company,92
+C001308,Massachusetts Electric Company,93
+C002045,Montana-Dakota Utilities Co.,95
+C000318,Metropolitan Edison Company,96
+C001673,"ALLETE, Inc.",98
+C001555,Mississippi Power Company,99
+C000849,"Entergy Mississippi, LLC",100
+C000906,MONONGAHELA POWER COMPANY,101
+R001105,Mt. Carmel Public Utility Co,105
+C001309,The Narragansett Electric Company,107
+C001610,"Nevada Power Company, d/b/a NV Energy",108
+C001654,New England Electric Transmission Corporation,110
+C001656,"New England Hydro-Trans. Elec. Co., Inc.",111
+C001655,New England Hydro-Transmission Corporation,112
+C001305,New England Power Company,113
+C000850,"Entergy New Orleans, LLC",114
+C000618,New York State Electric & Gas Corporation,115
+C001306,Niagara Mohawk Power Corporation,117
+C000542,Northern Indiana Public Service Company LLC,119
+C000824,Northern States Power Company (Minnesota),120
+C000823,Northern States Power Company (Wisconsin),121
+C001789,NorthWestern Corporation,122
+R001123,Northwestern Wisconsin Electric Company,123
+C000313,Ohio Edison Company,126
+C000535,Ohio Power Company,127
+C000622,Ohio Valley Electric Corporation,128
+C001444,Old Dominion Electric Cooperative,129
+C001775,Oklahoma Gas and Electric Company,130
+C000507,"Orange and Rockland Utilities, Inc",131
+C001288,Otter Tail Power Company,132
+C000388,PACIFIC GAS AND ELECTRIC COMPANY,133
+C001646,PacifiCorp,134
+C000201,PECO Energy Company,135
+C000317,Pennsylvania Electric Company,136
+C000316,Pennsylvania Power Company,137
+C001230,PPL Electric Utilities Corporation,138
+R001140,Pioneer Power and Light Company,140
+C001132,Portland General Electric Company,141
+C000913,THE POTOMAC EDISON COMPANY,142
+C001464,Potomac Electric Power Company,143
+C000289,"Duke Energy Indiana, LLC",144
+C000822,Public Service Company of Colorado,145
+C001017,Public Service Company of New Hampshire,146
+C001218,Public Service Company of New Mexico,147
+C000536,Public Service Company of Oklahoma,148
+C001194,Public Service Electric and Gas Company,149
+C000171,"Puget Sound Energy, Inc.",150
+C000617,Rochester Gas and Electric Corporation,151
+R001152,Rockland Electric Company,152
+C001707,Safe Harbor Water Power Corporation,153
+C000685,San Diego Gas & Electric Company,155
+C001609,Sierra Pacific Power Company d/b/a NV Energy,157
+C000241,"Dominion Energy South Carolina, Inc.",159
+R001160,"South Carolina Generating Company, Inc.",160
+C000041,Southern California Edison Company,161
+C001559,SOUTHERN ELECTRIC GENERATING COMPANY,162
+C001009,Southern Indiana Gas and Electric Company,163
+C000537,Southwestern Electric Power Company,164
+C000825,Southwestern Public Service Company,166
+R001167,"Superior Water, Light and Power Company",167
+C000852,"System Energy Resources, Inc.",169
+C000116,Tampa Electric Company,170
+C001330,Alcoa Power Generating Inc.,171
+C000315,"Toledo Edison Company, The",175
+C001184,Tucson Electric Power Company,176
+C000744,UNION ELECTRIC COMPANY,177
+C000291,"Duke Energy Kentucky, Inc.",178
+C001607,The United Illuminating Company,179
+C000501,Upper Peninsula Power Company,181
+C001182,"Evergy Missouri West, Inc.",182
+C001675,"Vermont Electric Power Company, Inc.",183
+C001252,"Vermont Electric Transmission Company, Inc.",184
+C001446,Vermont Yankee Nuclear Power Corporation,185
+C000196,VIRGINIA ELECTRIC AND POWER COMPANY,186
+C000379,Avista Corporation,187
+C000905,WEST PENN POWER COMPANY,188
+C000529,AEP Texas North Company,189
+C001018,Western Massachusetts Electric Company,190
+C000772,"Evergy Kansas Central, Inc.",191
+C000538,Wheeling Power Company,192
+C001316,Wisconsin Electric Power Company,193
+C000691,Wisconsin Power and Light Company,194
+C000500,Wisconsin Public Service Corporation,195
+C000502,Wisconsin River Power Company,196
+C002116,Yankee Atomic Electric Company,198
+R001202,"Chugach Electric Association, Inc.",202
+C001143,MidAmerican Energy Company,210
+C001245,Deseret Generation & Transmission Cooperative,226
+C001188,"Wolverine Power Supply Cooperative, Inc.",227
+C001183,California Independent System Operator Corporation,229
+C003244,"Hermiston Generating Company, L.P.",230
+C000029,ISO New England Inc.,231
+C002447,"Buckeye Power, Inc.",245
+C000038,New York Independent System Operator,250
+C000030,"PJM Interconnection, LLC",255
+C000319,"American Transmission Systems, Incorporated",258
+C004924,"Midwest Electric Power, Inc",262
+C000749,Ameren Energy Generating Company,266
+R001268,"Sharyland Utilities, L.P.",268
+C001225,Golden State Water Company,269
+C001344,"Midcontinent Independent System Operator, Inc",274
+C000319,American Transmission Company LLC,275
+C003435,"Evergy Generating, Inc.",276
+C000692,Interstate Power and Light Company,281
+C001486,Oncor Electric Delivery Company LLC,282
+C001187,"UNS Electric, Inc.",288
+C002446,International Transmission Company,289
+C001222,"Unitil Energy Systems, Inc.",290
+C000045,"Wabash Valley Power Association, Inc.",294
+C002083,"DATC Path 15, LLC",295
+C000771,"Southwest Power Pool, Inc.",297
+R001298,"Perryville Energy Partners, L.L.C",298
+R001301,Attala Transmission LLC,301
+C000862,"EWO Marketing, LLC",305
+C002101,Michigan Electric Transmission Company LLC (10/06),308
+C001257,NSTAR Electric Company,309
+R001311,Trans-Allegheny Interstate Line Company,311
+C000367,"Wabash Valley Energy Marketing, Inc.",312
+R001313,"Path Allegheny Transmission Company, LLC",313
+R001314,"Path West Virginia Transmission Company, L.L.C.",314
+C000851,"Entergy Texas, Inc.",315
+C002525,ITC Midwest LLC,316
+C002073,"Startrans IO, LLC",318
+R001319,"Prairie Wind Transmission, LLC",319
+C001252,Vermont Transco LLC,320
+C002854,Citizens Sunrise Transmission LLC.,321
+C005067,GridLiance High Plains LLC,322
+C001454,"Cheyenne Light, Fuel and Power Company",403
+R001416,Nantucket Electric Company,416
+R001418,"North Central Power Co., Inc.",418
+R001419,"Omya, Inc.",419
+R001422,Pike County Light and Power Company,422
+C002089,"UGI Utilities, Inc.",428
+C001696,"Black Hills Colorado Electric, LLC",432
+C003138,"ITC Great Plains, LLC",433
+R001435,"New Hampshire Transmission, LLC",435
+R001436,"AEP Appalachian Transmission Company, Inc.",436
+R001437,"AEP West Virginia Transmission Company, Inc.",437
+C000524,"AEP Ohio Transmission Company, Inc.",438
+R001439,"AEP Kentucky Transmission Company, Inc.",439
+R001440,"AEP Indiana Michigan Transmission Company, Inc.",440
+R001441,"AEP Southwestern Transmission Company, Inc.",441
+C000525,"AEP Oklahoma Transmission Company, Inc.",442
+C000746,Ameren Illinois Company,443
+C002196,Ameren Transmission Company of Illinois,444
+R001445,SU FERC L.L.C,445
+C002308,Trans Bay Cable LLC,446
+R001447,"PJM Settlement, Inc.",447
+C002523,"EAM Nelson Holding, LLC",449
+C003203,Smoky Mountain Transmission LLC,451
+C002925,AEP Generation Resources Inc.,452
+C003194,"Transource Missouri, LLC",453
+C004995,"Entergy Louisiana, LLC",454
+C004936,ITC Interconnection LLC,455
+R001512,"Transource West Virginia, LLC",512
+C005239,"4C Acquisition, LLC",513
+C007565,AEP Texas Inc.,514
+R001515,"New York Transco, LLC",515
+C005475,"Mid-Atlantic Interstate Transmission, LLC",516
+C007584,Cube Yadkin Transmission LLC,517
+C005519,GridLiance West LLC,518
+C005443,Upper Michigan Energy Resources Corporation,519
+R001520,"Transource Pennsylvania, LLC",520
+R001521,"Transource Maryland, LLC",521
+C000945,Liberty Utilities (CalPeco Electric) LLC,522
+R001523,"Pioneer Transmission, LLC",523
+C009068,GridLiance Heartland LLC,526
+C003988,"MidAmerican Central California Transco, LLC",527
+C008947,Citizens Sycamore-Penasquitos Transmission LLC,528
+C003836,"Tri-State Generation and Transmission Association, Inc.",529
+C004881,"Horizon West Transmission, LLC",530
+C003849,Basin Electric Power Cooperative,531
+C005059,"Silver Run Electric, LLC",532
+C010151,"Republic Transmission, LLC",533
+C010388,"Upper Missouri G & T Electric Cooperative, Inc. dba Upper Missouri Poe",536
+C010464,"Bear Valley Electric Service, Inc.",537
+C005444,"DesertLink, LLC",538
+C005424,"NextEra Energy Transmission MidAtlantic Indiana, Inc.",539
+C010446,"Wilderness Line Holdings, LLC",540
+C010432,"McKenzie Electric Cooperative, Inc.",541
+C010143,LS Power Grid New York Corporation I,542


### PR DESCRIPTION
This PR includes a notebook used for developing a mapping between FERC `respondent_id`'s and `entity_id`'s (also called Company Identifiers or CID's). This mapping will ultimately be added to PUDL, but the purpose of this PR is to verify the methodology for creating this map in the notebook in question.