### PR TITLE
Relax coloredlogs version to accommodate for dagster

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     license="MIT",
     install_requires=[
         "pydantic>=1.9,<2",
-        "coloredlogs~=15.0",
+        "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
         "catalystcoop.arelle-mirror==1.3.0",
         "frictionless>=4.4,<5",
         "sqlalchemy>=1.4,<2",


### PR DESCRIPTION
For some reason, dagster requires `coloredlogs<=14.0`. This change won't break PUDL because it requires `coloredlogs~=15.0`. 