### PR TITLE
Handle empty files and attempt to deduplicate more deeply

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ batches of 50 filings at a time.
         --batch-size 50
 
 There are also several options included for extracting metadata from the taxonomy.
-First is the ``--save-datapackage`` command to save a
+First is the ``--datapackage-path`` command to save a
 `frictionless datapackage <https://specs.frictionlessdata.io/data-package/>`__
 descriptor as JSON, which annotates the generated SQLite database. There is also the
 ``--metadata-path`` option, which writes more extensive taxonomy metadata to a json
@@ -177,4 +177,4 @@ filings and taxonomy, run the following command.
         --taxonomy examples/taxonomy.zip \
         --archive-path taxonomy/form1/2021-01-01/form/form1/form-1_2021-01-01.xsd \
         --metadata-path metadata.json \
-        --save-datapackage datapackage.json
+        --datapackage-path datapackage.json

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 
 def _taxonomy_view(taxonomy_source: str | FileSource.FileSource):
-    """Actually use Arelle to get a taxonomy its relationships."""
+    """Actually use Arelle to get a taxonomy and its relationships."""
     cntlr = Cntlr.Cntlr()
     cntlr.startLogging(logFileName="logToPrint")
     model_manager = ModelManager.initialize(cntlr)

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -1,4 +1,5 @@
 """Abstract away interface to Arelle XBRL Library."""
+from pathlib import Path
 from typing import Literal
 
 import pydantic
@@ -9,44 +10,41 @@ from arelle.ViewFileRelationshipSet import ViewRelationshipSet
 from pydantic import BaseModel
 
 
-def load_xbrl(path: str | FileSource.FileSource):
-    """Load XBRL (either taxonomy or individual filing).
-
-    Args:
-        path: URL or local path pointing to an XBRL taxonomy or instance.
-    """
+def _taxonomy_view(taxonomy_source: str | FileSource.FileSource):
+    """Actually use Arelle to get a taxonomy its relationships."""
     cntlr = Cntlr.Cntlr()
     cntlr.startLogging(logFileName="logToPrint")
     model_manager = ModelManager.initialize(cntlr)
-    return ModelXbrl.load(model_manager, path)
+    taxonomy = ModelXbrl.load(model_manager, taxonomy_source)
 
-
-def load_taxonomy(path: str | FileSource.FileSource):
-    """Load XBRL taxonomy, and parse relationships.
-
-    Args:
-        path: URL or local path pointing to an XBRL taxonomy.
-    """
-    taxonomy = load_xbrl(path)
-
-    # Interpret structure/relationships
     view = ViewRelationshipSet(taxonomy, "taxonomy.json", "roles", None, None, None)
     view.view(XbrlConst.parentChild, None, None, None)
 
     return taxonomy, view
 
 
-def load_taxonomy_from_archive(filepath: str, archive_path: str):
+def load_taxonomy(path: Path):
+    """Load XBRL taxonomy, and parse relationships.
+
+    Args:
+        path: URL or local path pointing to an XBRL taxonomy.
+    """
+    # arelle only works with `str`, not `Path` - as of version 2.12.2
+    source = str(path)
+    return _taxonomy_view(source)
+
+
+def load_taxonomy_from_archive(filepath: Path, archive_path: Path):
     """Load an XBRL taxonomy from a zipfile archive.
 
     Args:
         filepath: Path to zipfile on disc.
         archive_path: Relative path to taxonomy entry point within archive.
     """
-    # Create arelle FileSource object
-    f = FileSource.openFileSource(archive_path, sourceZipStream=filepath)
-
-    return load_taxonomy(f)
+    file_source = FileSource.openFileSource(
+        str(archive_path), sourceZipStream=str(filepath)
+    )
+    return _taxonomy_view(file_source)
 
 
 class References(BaseModel):

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -119,8 +119,8 @@ def run_main(
         file_logger.setFormatter(logging.Formatter(log_format))
         logger.addHandler(file_logger)
 
-    db_path = f"sqlite:///{sql_path}"
-    engine = create_engine(db_path)
+    db_uri = f"sqlite:///{sql_path}"
+    engine = create_engine(db_uri)
 
     if clobber:
         helpers.drop_tables(engine)
@@ -141,7 +141,7 @@ def run_main(
     extracted = xbrl.extract(
         taxonomy_path=taxonomy,
         form_number=form_number,
-        db_path=db_path,
+        db_uri=db_uri,
         archive_path=archive_path,
         datapackage_path=datapackage_path,
         metadata_path=metadata_path,
@@ -151,10 +151,10 @@ def run_main(
     )
 
     with engine.begin() as conn:
-        for table_name, filing in extracted.filings.items():
+        for table_name, data in extracted.table_data.items():
             # Loop through tables and write to database
-            if not filing.empty:
-                filing.to_sql(table_name, conn, if_exists="append")
+            if not data.empty:
+                data.to_sql(table_name, conn, if_exists="append")
 
 
 def main():

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -1,9 +1,7 @@
 """A command line interface (CLI) to the xbrl extractor."""
 import argparse
-import io
 import logging
 import sys
-import zipfile
 from pathlib import Path
 
 import coloredlogs
@@ -11,7 +9,6 @@ from sqlalchemy import create_engine
 
 from ferc_xbrl_extractor import helpers, xbrl
 from ferc_xbrl_extractor.helpers import get_logger
-from ferc_xbrl_extractor.instance import InstanceBuilder
 
 TAXONOMY_MAP = {
     1: "https://eCollection.ferc.gov/taxonomy/form1/2022-01-01/form/form1/form-1_2022-01-01.xsd",
@@ -22,7 +19,7 @@ TAXONOMY_MAP = {
 }
 
 
-def parse_main():
+def parse():
     """Process base commands from the CLI."""
     parser = argparse.ArgumentParser(description="Extract data from XBRL filings")
     parser.add_argument(
@@ -34,8 +31,9 @@ def parse_main():
     )
     parser.add_argument(
         "-s",
-        "--save-datapackage",
+        "--datapackage-path",
         default=None,
+        type=Path,
         help="Generate frictionless datapackage descriptor, and write to JSON file at specified path.",
     )
     parser.add_argument(
@@ -76,14 +74,14 @@ def parse_main():
         "-a",
         "--archive-path",
         default=None,
-        type=str,
+        type=Path,
         help="Specify path to taxonomy entry point within a zipfile archive. This is a relative path within the taxonomy. If specified, `taxonomy` must be set to point to the zipfile location on the local file system.",
     )
     parser.add_argument(
         "-m",
         "--metadata-path",
         default=None,
-        type=str,
+        type=Path,
         help="Specify path to output metadata extracted taxonomy. Metadata will not be extracted if no path is specified.",
     )
     parser.add_argument(
@@ -91,123 +89,77 @@ def parse_main():
         help="Set log level (valid arguments include DEBUG, INFO, WARNING, ERROR, CRITICAL)",
         default="INFO",
     )
-    parser.add_argument("--logfile", help="Path to logfile", default=None)
+    parser.add_argument("--logfile", help="Path to logfile", type=Path, default=None)
 
     return parser.parse_args()
 
 
-def instances_from_zip(instance_path: Path) -> list[InstanceBuilder]:
-    """Get list of instances from specified path to zipfile.
-
-    Args:
-        instance_path: Path to zipfile containing XBRL filings.
-    """
-    allowable_suffixes = [".xbrl"]
-
-    archive = zipfile.ZipFile(instance_path)
-
-    # Read files into in memory buffers to parse
-    return [
-        InstanceBuilder(
-            io.BytesIO(archive.open(filename).read()), filename.split(".")[0]
-        )
-        for filename in archive.namelist()
-        if Path(filename).suffix in allowable_suffixes
-    ]
-
-
-def get_instances(instance_path: Path) -> list[InstanceBuilder]:
-    """Get list of instances from specified path.
-
-    Args:
-        instance_path: Path to one or more XBRL filings.
-    """
-    allowable_suffixes = [".xbrl"]
-
-    if not instance_path.exists():
-        raise ValueError(
-            "Must provide valid path to XBRL instance or directory" "of XBRL instances."
-        )
-
-    if instance_path.suffix == ".zip":
-        return instances_from_zip(instance_path)
-
-    # Single instance
-    if instance_path.is_file():
-        instances = [instance_path]
-    # Directory of instances
-    else:
-        # Must be either a directory or file
-        assert instance_path.is_dir()  # nosec: B101
-        instances = sorted(instance_path.iterdir())
-
-    return [
-        InstanceBuilder(str(instance), instance.name.rstrip(instance.suffix))
-        for instance in sorted(instances)
-        if instance.suffix in allowable_suffixes
-    ]
-
-
-def main():
-    """CLI for extracting data fro XBRL filings."""
-    args = parse_main()
-
+def run_main(
+    instance_path: Path,
+    sql_path: Path,
+    clobber: bool,
+    taxonomy: str | None,
+    archive_path: Path,
+    form_number: int,
+    metadata_path: Path | None,
+    datapackage_path: Path | None,
+    workers: int | None,
+    batch_size: int | None,
+    loglevel: str,
+    logfile: Path | None,
+):
+    """Log setup, taxonomy finding, and SQL IO."""
     logger = get_logger("ferc_xbrl_extractor")
-    logger.setLevel(args.loglevel)
+    logger.setLevel(loglevel)
     log_format = "%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s"
-    coloredlogs.install(fmt=log_format, level=args.loglevel, logger=logger)
+    coloredlogs.install(fmt=log_format, level=loglevel, logger=logger)
 
-    if args.logfile:
-        file_logger = logging.FileHandler(args.logfile)
+    if logfile:
+        file_logger = logging.FileHandler(logfile)
         file_logger.setFormatter(logging.Formatter(log_format))
         logger.addHandler(file_logger)
 
-    engine = create_engine(f"sqlite:///{args.sql_path}")
+    db_path = f"sqlite:///{sql_path}"
+    engine = create_engine(db_path)
 
-    if args.clobber:
+    if clobber:
         helpers.drop_tables(engine)
 
     # Verify taxonomy is set if archive_path is set
-    if args.archive_path and not args.taxonomy:
+    if archive_path and not taxonomy:
         raise ValueError("taxonomy must be set if archive_path is given.")
 
     # Get taxonomy URL
-    if args.taxonomy:
-        taxonomy = args.taxonomy
-    else:
-        if args.form_number not in TAXONOMY_MAP:
+    if taxonomy is None:
+        if form_number not in TAXONOMY_MAP:
             raise ValueError(
-                f"Form number {args.form_number} is not valid. Supported form numbers include {list(TAXONOMY_MAP.keys())}"
+                f"Form number {form_number} is not valid. Supported form numbers include {list(TAXONOMY_MAP.keys())}"
             )
-
         # Get most recent taxonomy for specified form number
-        taxonomy = TAXONOMY_MAP[args.form_number]
+        taxonomy = TAXONOMY_MAP[form_number]
 
-    tables = xbrl.get_fact_tables(
+    extracted = xbrl.extract(
         taxonomy_path=taxonomy,
-        form_number=args.form_number,
-        db_path=str(engine.url),
-        archive_file_path=args.archive_path,
-        datapackage_path=args.save_datapackage,
-        metadata_path=args.metadata_path,
-    )
-
-    instances = [
-        i.parse()
-        for i in get_instances(
-            Path(args.instance_path),
-        )
-    ]
-
-    filings, stats = xbrl.extract(
-        instances, tables, workers=args.workers, batch_size=args.batch_size
+        form_number=form_number,
+        db_path=db_path,
+        archive_path=archive_path,
+        datapackage_path=datapackage_path,
+        metadata_path=metadata_path,
+        instance_path=instance_path,
+        workers=workers,
+        batch_size=batch_size,
     )
 
     with engine.begin() as conn:
-        for table_name, filing in filings.items():
+        for table_name, filing in extracted.filings.items():
             # Loop through tables and write to database
             if not filing.empty:
                 filing.to_sql(table_name, conn, if_exists="append")
+
+
+def main():
+    """Parse arguments and pass to run_main."""
+    return run_main(**vars(parse()))
 
 
 if __name__ == "__main__":

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -1,8 +1,10 @@
 """Parse a single instance."""
 import io
 import itertools
+import zipfile
 from collections import Counter, defaultdict
 from enum import Enum, auto
+from pathlib import Path
 from typing import BinaryIO
 
 import stringcase
@@ -333,13 +335,11 @@ class InstanceBuilder:
         parser = etree.XMLParser(huge_tree=True)
 
         # Check if instance contains path to file or file data and parse accordingly
-        if isinstance(self.file, str):
+        try:
             tree = etree.parse(self.file, parser=parser)  # nosec: B320
-            root = tree.getroot()
-        elif isinstance(self.file, io.BytesIO):
-            root = etree.fromstring(self.file.read(), parser=parser)  # nosec: B320
-        else:
-            raise TypeError("Can only parse XBRL from path to file or file like object")
+        except etree.XMLSyntaxError:
+            return None
+        root = tree.getroot()
 
         # Dictionary mapping context ID's to context structures
         context_dict = {}
@@ -372,3 +372,53 @@ class InstanceBuilder:
                     duration_facts[new_fact.name].append(new_fact)
 
         return Instance(context_dict, instant_facts, duration_facts, self.name)
+
+
+def instances_from_zip(instance_path: Path) -> list[InstanceBuilder]:
+    """Get list of instances from specified path to zipfile.
+
+    Args:
+        instance_path: Path to zipfile containing XBRL filings.
+    """
+    allowable_suffixes = [".xbrl"]
+
+    archive = zipfile.ZipFile(instance_path)
+
+    # Read files into in memory buffers to parse
+    return [
+        InstanceBuilder(
+            io.BytesIO(archive.open(filename).read()), filename.split(".")[0]
+        )
+        for filename in archive.namelist()
+        if Path(filename).suffix in allowable_suffixes
+    ]
+
+
+def get_instances(instance_path: Path) -> list[InstanceBuilder]:
+    """Get list of instances from specified path.
+
+    Args:
+        instance_path: Path to one or more XBRL filings.
+    """
+    allowable_suffixes = [".xbrl"]
+
+    if not instance_path.exists():
+        raise ValueError(f"Could not find XBRL instances at {instance_path}.")
+
+    if instance_path.suffix == ".zip":
+        return instances_from_zip(instance_path)
+
+    # Single instance
+    if instance_path.is_file():
+        instances = [instance_path]
+    # Directory of instances
+    else:
+        # Must be either a directory or file
+        assert instance_path.is_dir()  # nosec: B101
+        instances = sorted(instance_path.iterdir())
+
+    return [
+        InstanceBuilder(str(instance), instance.name.rstrip(instance.suffix))
+        for instance in sorted(instances)
+        if instance.suffix in allowable_suffixes
+    ]

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -271,7 +271,7 @@ class Instance:
             )
         ]
         if self.duplicated_fact_ids:
-            self.logger.info(
+            self.logger.debug(
                 f"Duplicated facts in {filing_name}: {self.duplicated_fact_ids}"
             )
         self.used_fact_ids: set[str] = set()
@@ -335,10 +335,7 @@ class InstanceBuilder:
         parser = etree.XMLParser(huge_tree=True)
 
         # Check if instance contains path to file or file data and parse accordingly
-        try:
-            tree = etree.parse(self.file, parser=parser)  # nosec: B320
-        except etree.XMLSyntaxError:
-            return None
+        tree = etree.parse(self.file, parser=parser)  # nosec: B320
         root = tree.getroot()
 
         # Dictionary mapping context ID's to context structures

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -230,8 +230,8 @@ class Taxonomy(BaseModel):
     @classmethod
     def from_path(
         cls,
-        path: str,
-        archive_file_path: str | None = None,
+        path: Path,
+        archive_path: Path | None = None,
     ):
         """Construct taxonomy from taxonomy URL.
 
@@ -242,13 +242,13 @@ class Taxonomy(BaseModel):
 
         Args:
             path: URL or local path to taxonomy.
-            archive_file_path: Path to taxonomy entry point within archive. If not None,
+            archive_path: Path to taxonomy entry point within archive. If not None,
                 then `taxonomy` should be a path to zipfile, not a URL.
         """
-        if not archive_file_path:
+        if not archive_path:
             taxonomy, view = load_taxonomy(path)
         else:
-            taxonomy, view = load_taxonomy_from_archive(path, archive_file_path)
+            taxonomy, view = load_taxonomy_from_archive(path, archive_path)
 
         # Create dictionary mapping concept names to concepts
         concept_dict = {

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -154,16 +154,13 @@ def process_batch(
         instances: Iterator of instances.
         table_defs: Dictionary mapping table names to FactTable objects describing table structure.
     """
-    dfs: dict[str, pd.DataFrame] = {}
+    dfs: defaultdict[str, list[pd.DataFrame]] = defaultdict(list)
     fact_ids = {}
     for instance in instances:
         # Convert XBRL instance to dataframes. Log/skip if file is empty
         instance_dfs = process_instance(instance, table_defs)
 
         for key, df in instance_dfs.items():
-            if key not in dfs:
-                dfs[key] = []
-
             dfs[key].append(df)
         fact_ids[instance.filing_name] = instance.used_fact_ids
 

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -34,6 +34,7 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
     out_db = tmp_path / "ferc1-2021-sample.sqlite"
     metadata = tmp_path / "metadata.json"
     datapackage = tmp_path / "datapackage.json"
+    log_file = tmp_path / "log.log"
     data_dir = test_dir / "integration" / "data"
 
     ret = script_runner.run(
@@ -48,6 +49,68 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
         str(metadata),
         "--datapackage-path",
         str(datapackage),
+        "--logfile",
+        str(log_file),
     )
 
     assert ret.success
+
+
+@pytest.mark.script_launch_mode("inprocess")
+def test_extract_example_filings_no_explicit_taxonomy(
+    script_runner, tmp_path, test_dir
+):
+    """Test the XBRL extraction on the example filings.
+
+    Same as above, but should look up the taxonomy using the TAXONOMY_MAP.
+
+    """
+    out_db = tmp_path / "ferc1-2021-sample.sqlite"
+    metadata = tmp_path / "metadata.json"
+    datapackage = tmp_path / "datapackage.json"
+    log_file = tmp_path / "log.log"
+    data_dir = test_dir / "integration" / "data"
+
+    ret = script_runner.run(
+        "xbrl_extract",
+        str(data_dir / "ferc1-xbrl-2021.zip"),
+        str(out_db),
+        "--metadata-path",
+        str(metadata),
+        "--datapackage-path",
+        str(datapackage),
+        "--logfile",
+        str(log_file),
+    )
+
+    assert ret.success
+
+
+@pytest.mark.script_launch_mode("inprocess")
+def test_extract_example_filings_bad_form(script_runner, tmp_path, test_dir):
+    """Test the XBRL extraction on the example filings.
+
+    Should fail, because of a nonexistent form number.
+
+    """
+    out_db = tmp_path / "ferc1-2021-sample.sqlite"
+    metadata = tmp_path / "metadata.json"
+    datapackage = tmp_path / "datapackage.json"
+    log_file = tmp_path / "log.log"
+    data_dir = test_dir / "integration" / "data"
+
+    ret = script_runner.run(
+        "xbrl_extract",
+        str(data_dir / "ferc1-xbrl-2021.zip"),
+        str(out_db),
+        "--form-number",
+        "666",
+        "--metadata-path",
+        str(metadata),
+        "--datapackage-path",
+        str(datapackage),
+        "--logfile",
+        str(log_file),
+    )
+
+    assert not ret.success

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -46,7 +46,7 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
         "taxonomy/form1/2021-01-01/form/form1/form-1_2021-01-01.xsd",
         "--metadata-path",
         str(metadata),
-        "--save-datapackage",
+        "--datapackage-path",
         str(datapackage),
     )
 

--- a/tests/unit/datapackage_test.py
+++ b/tests/unit/datapackage_test.py
@@ -138,10 +138,11 @@ def test_fuzzy_dedup():
     df = pd.DataFrame(
         [
             {"c_id": "a", "name": "cost", "value": 1.0},
-            {"c_id": "a", "name": "cost", "value": 1.0000001},
-            {"c_id": "a", "name": "cost", "value": 1.0000002},
+            {"c_id": "a", "name": "cost", "value": 1.1},
             {"c_id": "a", "name": "job", "value": "accountant"},
             {"c_id": "b", "name": "cost", "value": 2.0},
+            {"c_id": "b", "name": "cost", "value": 2.1},
+            {"c_id": "b", "name": "cost", "value": 2.15},
             {"c_id": "b", "name": "job", "value": "Councilor"},
             {"c_id": "c", "name": "cost", "value": 3.0},
             {"c_id": "c", "name": "job", "value": "custodian"},
@@ -149,9 +150,9 @@ def test_fuzzy_dedup():
     ).set_index(fact_index)
     expected = pd.DataFrame(
         [
-            {"c_id": "a", "name": "cost", "value": 1.0},
+            {"c_id": "a", "name": "cost", "value": 1.1},
             {"c_id": "a", "name": "job", "value": "accountant"},
-            {"c_id": "b", "name": "cost", "value": 2.0},
+            {"c_id": "b", "name": "cost", "value": 2.15},
             {"c_id": "b", "name": "job", "value": "Councilor"},
             {"c_id": "c", "name": "cost", "value": 3.0},
             {"c_id": "c", "name": "job", "value": "custodian"},

--- a/tests/unit/datapackage_test.py
+++ b/tests/unit/datapackage_test.py
@@ -160,3 +160,30 @@ def test_fuzzy_dedup():
     ).set_index(fact_index)
 
     pd.testing.assert_frame_equal(fuzzy_dedup(df), expected)
+
+
+def test_fuzzy_dedup_failed_to_resolve():
+    fact_index = ["c_id", "name"]
+    df = pd.DataFrame(
+        [
+            {"c_id": "a", "name": "cost", "value": 1.1},
+            {"c_id": "a", "name": "cost", "value": 1.2},
+            {"c_id": "a", "name": "job", "value": "accountant"},
+        ]
+    ).set_index(fact_index)
+
+    with pytest.raises(ValueError, match=r"Fact a:cost has values.*1.1.*1.2"):
+        fuzzy_dedup(df)
+
+    df = pd.DataFrame(
+        [
+            {"c_id": "a", "name": "cost", "value": 1.1},
+            {"c_id": "a", "name": "job", "value": "accountant"},
+            {"c_id": "a", "name": "job", "value": "pringle"},
+        ]
+    ).set_index(fact_index)
+
+    with pytest.raises(
+        ValueError, match=r"Fact a:job has values.*'accountant'.*'pringle'.*"
+    ):
+        fuzzy_dedup(df)

--- a/tests/unit/instance_test.py
+++ b/tests/unit/instance_test.py
@@ -12,6 +12,7 @@ from ferc_xbrl_extractor.instance import (
     Instance,
     InstanceBuilder,
     Period,
+    get_instances,
 )
 
 logger = logging.getLogger(__name__)
@@ -190,3 +191,8 @@ def test_all_fact_ids():
             "context_2:caveman_utterance": 1,
         }
     )
+
+
+def test_get_instances_wrong_path(tmp_path):
+    with pytest.raises(ValueError, match="Could not find XBRL instances"):
+        get_instances(tmp_path / "bogus")


### PR DESCRIPTION
This is to handle empty files in some filings - there's a bit of a yak-shave here:

* to handle empty files, we filter them out after trying to parse - I chose to pass back `None` as an error value, but we could also raise an error, or filter ahead of time, but whatever we choose...
* we need to run the filtering both in the `data_quality` test and the CLI, so...
* we should unify the "get a taxonomy, read instances, wire them into the actual dataframe-construction" logic...
* so we might as well clean up the CLI code slightly

Unfortunately I added a bit more deduplication logic in here, since I found a deduplication bug when testing this out. I can pull that into #117 if that's easier for you, @zschira .