### PR TITLE
Fix memory issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ tests = [
     "pytest>=6.2,<7.5",  # Our testing framework
     "pytest-console-scripts>=1.1,<1.5",  # Allow automatic testing of scripts
     "pytest-cov>=2.10,<4.2",  # Pytest plugin for working with coverage
+    "pytest-mock>=3.0,<3.12",
     "ruff>=0.0.289",  # A very fast linter and autofixer
     "tox>=4.0,<4.12",  # Python test environment manager
 ]

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -265,6 +265,7 @@ class Instance:
                 (instant_facts | duration_facts).values()
             )
         )
+        self.total_facts = len(self.fact_id_counts)
         self.duplicated_fact_ids = [
             f_id
             for f_id, _ in itertools.takewhile(

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -1,6 +1,85 @@
+import pandas as pd
+from lxml.etree import XMLSyntaxError  # nosec: B410
+
 from ferc_xbrl_extractor.datapackage import FactTable, Field, Schema
 from ferc_xbrl_extractor.instance import InstanceBuilder
-from ferc_xbrl_extractor.xbrl import table_data_from_instances
+from ferc_xbrl_extractor.xbrl import process_batch, table_data_from_instances
+
+
+def test_process_batch(mocker):
+    class MockInstanceBuilder:
+        def __init__(
+            self, filing_name, used_fact_ids, total_facts, raise_exception=False
+        ):
+            self.raise_exception = raise_exception
+            self.filing_name = filing_name
+            self.name = filing_name
+            self.used_fact_ids = used_fact_ids
+            self.total_facts = total_facts
+
+        def parse(self):
+            if self.raise_exception:
+                raise XMLSyntaxError("message", 1, 0, 0)
+            return self
+
+    test_data = {
+        "instance_1": {
+            "raise_exception": False,
+            "used_fact_ids": 3,
+            "total_facts": 4,
+        },
+        "instance_2": {"raise_exception": False, "used_fact_ids": 5, "total_facts": 8},
+        "instance_3": {"raise_exception": False, "used_fact_ids": 8, "total_facts": 9},
+        "instance_4": {"raise_exception": True, "used_fact_ids": 12, "total_facts": 13},
+    }
+
+    instances = [
+        MockInstanceBuilder(
+            key, vals["used_fact_ids"], vals["total_facts"], vals["raise_exception"]
+        )
+        for key, vals in test_data.items()
+    ]
+    table_defs = ["table_1", "table_2", "table_3"]
+
+    mocker.patch(
+        "ferc_xbrl_extractor.xbrl.process_instance",
+        side_effect=lambda instance, tables: {
+            table: pd.DataFrame({table: [instance.filing_name]}) for table in tables
+        },
+    )
+
+    expected_dfs = {
+        table: pd.DataFrame(
+            {
+                table: [
+                    filing_name
+                    for filing_name, vals in test_data.items()
+                    if not vals["raise_exception"]
+                ]
+            }
+        )
+        for table in table_defs
+    }
+
+    results = process_batch(instances, table_defs)
+
+    for table in table_defs:
+        pd.testing.assert_frame_equal(
+            expected_dfs[table], results["dfs"][table].reset_index(drop=True)
+        )
+
+    metadata = results["metadata"]
+    for filing_name, expected_metadata in test_data.items():
+        if not expected_metadata["raise_exception"]:
+            assert (
+                metadata[filing_name]["used_facts"]
+                == expected_metadata["used_fact_ids"]
+            )
+            assert (
+                metadata[filing_name]["total_facts"] == expected_metadata["total_facts"]
+            )
+        else:
+            assert filing_name not in metadata
 
 
 def test_table_data_dedupes(multi_filings):

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -7,7 +7,6 @@ def test_table_data_dedupes(multi_filings):
     instance_builders = [
         InstanceBuilder(f, name=f"instance_{i}") for i, f in enumerate(multi_filings)
     ]
-    instances = [ib.parse() for ib in instance_builders]
 
     duration_schema = Schema(
         fields=[
@@ -31,7 +30,7 @@ def test_table_data_dedupes(multi_filings):
         "duration": FactTable(schema=duration_schema, period_type="duration"),
     }
     table_data, _stats = table_data_from_instances(
-        instances=instances,
+        instance_builders=instance_builders,
         table_defs=taxonomy,
     )
 


### PR DESCRIPTION
This PR fixes the high memory usage introduced in `1.0.0`. This problem was caused by parsing `Instance`'s at the beginning, and passing the parsed objects to the worker processes. These objects are quite large, and get copied when passed to subprocesses, which lead to huge increases in total memory usage. This PR reverts to parsing these objects when they are needed in each subprocess. It also slightly reworks some integration tests to accommodate this change.