### PR TITLE
Switch to using setup-micromamba action

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -9,24 +9,29 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11"]
       fail-fast: false
+    defaults:
+      run:
+        shell: bash -l {0}
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
-      - name: Set up conda environment for testing
-        uses: conda-incubator/setup-miniconda@v2.2.0
+      - name: Install Conda environment using mamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
-          python-version: ${{ matrix.python-version }}
-          activate-environment: ferc-xbrl-extractor
           environment-file: environment.yml
-      - shell: bash -l {0}
+          create-args: python=${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
+
+      - name: Log environment details
         run: |
           conda info
           conda list
@@ -36,10 +41,10 @@ jobs:
 
       - name: Run PyTest with Tox
         run: |
-          conda run -n ferc-xbrl-extractor tox
+          tox
 
       - name: Upload test coverage report to CodeCov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3
 
   ci-notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           environment-file: environment.yml
           create-args: python=${{ matrix.python-version }}
-          python-version: ${{ matrix.python-version }}
           cache-environment: true
           condarc: |
             channels:


### PR DESCRIPTION
Switch the `tox-pytest` workflow over to using the new and supported `mamba-org/setup-micromamba` action to create the conda environment.