### PR TITLE
Force tables to have all columns that are defined in schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   # Formatters: hooks that re-write Python and RST files
   ########################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.290
+    rev: v0.0.291
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ docs = [
     "doc8>=1.0,<1.2",  # Ensures clean documentation formatting
     "furo>=2022.4.7",
     "sphinx>=4,!=5.1.0,<7.3",  # The default Python documentation engine
-    "sphinx-autoapi>=2.0,<2.2",  # Generates documentation from docstrings
+    "sphinx-autoapi>=3.0,<4",  # Generates documentation from docstrings
     "sphinx-issues>=1.2,<3.1",  # Allows references to GitHub issues
 ]
 tests = [

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -374,6 +374,7 @@ class FactTable:
             .set_index(fact_index)
             .pipe(fuzzy_dedup)["value"]
             .unstack("name")
+            .reindex(columns=self.data_columns)
         )
 
         facts["report_date"] = instance.report_date

--- a/tests/integration/datapackage_test.py
+++ b/tests/integration/datapackage_test.py
@@ -48,6 +48,7 @@ def _create_schema(instant=True, axes=None):
             *axes,
             Field(name="column_one", title="", description=""),
             Field(name="column_two", title="", description=""),
+            Field(name="null_col", title="", description=""),
         ],
         primary_key=primary_key,
     )
@@ -61,9 +62,9 @@ def _create_schema(instant=True, axes=None):
             "duration",
             pd.read_csv(
                 io.StringIO(
-                    "c_id,entity_id,filing_name,start_date,end_date,column_one,column_two\n"
-                    'cid_1,EID1,filing,2021-01-01,2021-12-31,"value 1","value 2"\n'
-                    'cid_4,EID1,filing,2020-01-01,2020-12-31,"value 3","value 4"\n'
+                    "c_id,entity_id,filing_name,start_date,end_date,column_one,column_two,null_col\n"
+                    'cid_1,EID1,filing,2021-01-01,2021-12-31,"value 1","value 2",\n'
+                    'cid_4,EID1,filing,2020-01-01,2020-12-31,"value 3","value 4",\n'
                 )
             ),
         ),
@@ -72,10 +73,10 @@ def _create_schema(instant=True, axes=None):
             "duration",
             pd.read_csv(
                 io.StringIO(
-                    "c_id,entity_id,filing_name,start_date,end_date,dimension_one_axis,column_one,column_two\n"
-                    'cid_1,EID1,filing,2021-01-01,2021-12-31,total,"value 1","value 2"\n'
-                    'cid_4,EID1,filing,2020-01-01,2020-12-31,total,"value 3","value 4"\n'
-                    'cid_5,EID1,filing,2020-01-01,2020-12-31,"Dim 1 Value","value 9","value 10"\n'
+                    "c_id,entity_id,filing_name,start_date,end_date,dimension_one_axis,column_one,column_two,null_col\n"
+                    'cid_1,EID1,filing,2021-01-01,2021-12-31,total,"value 1","value 2",\n'
+                    'cid_4,EID1,filing,2020-01-01,2020-12-31,total,"value 3","value 4",\n'
+                    'cid_5,EID1,filing,2020-01-01,2020-12-31,"Dim 1 Value","value 9","value 10",\n'
                 )
             ),
         ),
@@ -84,9 +85,9 @@ def _create_schema(instant=True, axes=None):
             "instant",
             pd.read_csv(
                 io.StringIO(
-                    "c_id,entity_id,filing_name,date,dimension_one_axis,dimension_two_axis,column_one,column_two\n"
-                    'cid_2,EID1,filing,2021-12-31,total,total,"value 5","value 6"\n'
-                    'cid_3,EID1,filing,2021-12-31,"Dim 1 Value","ferc:Dimension2Value","value 7","value 8"\n'
+                    "c_id,entity_id,filing_name,date,dimension_one_axis,dimension_two_axis,column_one,column_two,null_col\n"
+                    'cid_2,EID1,filing,2021-12-31,total,total,"value 5","value 6",\n'
+                    'cid_3,EID1,filing,2021-12-31,"Dim 1 Value","ferc:Dimension2Value","value 7","value 8",\n'
                 )
             ),
         ),


### PR DESCRIPTION
In https://github.com/catalyst-cooperative/pudl/issues/2897 I found that we were missing some columns because the `.unstack()` in `construct_dataframe` doesn't create columns for values that don't show up at all, even if they're defined in the metadata. Applying a reindex makes sure we get everything.

This also was causing some integration test failures - when running the ETL in-process, we would:

1. write 2021 data for a table
2. construct dataframe for 2022 data, which has a slightly different column set because of different reported values
3. fail when trying to write 2022 data to SQLite

Lastly, I wonder if there's a way we could keep our extracted tables tidy - our transforms in PUDL promptly re-stack these wide tables in `wide_to_tidy`, so maybe we can skip that completely. But that's definitely out of scope of this PR.