### PR TITLE
Add table/instance filtering to speed up debugging process.

### DIFF
--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -93,6 +93,19 @@ def parse():
     )
     parser.add_argument("--logfile", help="Path to logfile", type=Path, default=None)
 
+    parser.add_argument(
+        "--instance-pattern",
+        help="Regex pattern for filing name - if not provided, defaults to '' which matches all.",
+        default=r"",
+    )
+
+    parser.add_argument(
+        "--requested-tables",
+        help="Table names to extract - if none, will default to all. Includes the _duration/_instant suffix.",
+        nargs="+",
+        default=None,
+    )
+
     return parser.parse_args()
 
 
@@ -109,6 +122,8 @@ def run_main(
     batch_size: int | None,
     loglevel: str,
     logfile: Path | None,
+    requested_tables: list[str] | None = None,
+    instance_pattern: str = None,
 ):
     """Log setup, taxonomy finding, and SQL IO."""
     logger = get_logger("ferc_xbrl_extractor")
@@ -150,6 +165,8 @@ def run_main(
         instance_path=instance_path,
         workers=workers,
         batch_size=batch_size,
+        requested_tables=requested_tables,
+        instance_pattern=instance_pattern,
     )
 
     with engine.begin() as conn:

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -429,7 +429,7 @@ class Datapackage(BaseModel):
                     If None, all possible tables will be extracted.
         """
         if filter_tables:
-            filtered_resources = {r for r in self.resources if r.name in filter_tables}
+            filtered_resources = (r for r in self.resources if r.name in filter_tables)
         else:
             filtered_resources = self.resources
         return {

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -1,6 +1,7 @@
 """XBRL extractor."""
 import io
 import math
+import re
 from collections import defaultdict, namedtuple
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor as Executor
@@ -29,6 +30,7 @@ def extract(
     datapackage_path: Path | None = None,
     metadata_path: Path | None = None,
     requested_tables: set[str] | None = None,
+    instance_pattern: str = r"",
     workers: int | None = None,
     batch_size: int | None = None,
 ) -> ExtractOutput:
@@ -48,6 +50,8 @@ def extract(
         metadata_path: where to write XBRL metadata to, if at all. Defaults
             to None, i.e., do not write one.
         requested_tables: only attempt to ingest data for these tables.
+        instance_pattern: only ingest data for instances matching this regex.
+            Defaults to empty string which matches all.
         workers: max number of workers to use.
         batch_size: max number of instances to parse for each worker.
     """
@@ -59,12 +63,21 @@ def extract(
         datapackage_path=datapackage_path,
         metadata_path=metadata_path,
     )
+    table_defs_to_extract = table_defs
+    if requested_tables:
+        table_defs_to_extract = {
+            tn: td for tn, td in table_defs.items() if tn in requested_tables
+        }
 
-    instances = get_instances(instance_path)
+    instance_builders = [
+        ib
+        for ib in get_instances(instance_path)
+        if re.search(instance_pattern, ib.name)
+    ]
+
     table_data, stats = table_data_from_instances(
-        instances,
-        table_defs,
-        requested_tables=requested_tables,
+        instance_builders,
+        table_defs_to_extract,
         workers=workers,
         batch_size=batch_size,
     )
@@ -96,7 +109,6 @@ def _dedupe_newer_report_wins(df: pd.DataFrame, primary_key: list[str]) -> pd.Da
 def table_data_from_instances(
     instance_builders: list[InstanceBuilder],
     table_defs: dict[str, FactTable],
-    requested_tables: set[str] | None = None,
     batch_size: int | None = None,
     workers: int | None = None,
 ) -> tuple[dict[str, pd.DataFrame], dict[str, list]]:
@@ -106,12 +118,9 @@ def table_data_from_instances(
 
     Args:
         instances: A list of Instance objects used for parsing XBRL filings.
-        table_defs: the tables defined in the taxonomy s.t. we can try to match
-            facts to them.
+        table_defs: the tables defined in the taxonomy that we will match facts to.
         archive_path: Path to taxonomy entry point within archive. If not None,
             then `taxonomy` should be a path to zipfile, not a URL.
-        requested_tables: Optionally specify the set of tables to extract.
-            If None, all possible tables will be extracted.
         batch_size: Number of filings to process before writing to DB.
         workers: Number of threads to create for parsing filings.
     """

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -62,12 +62,8 @@ def extract(
         entry_point=entry_point,
         datapackage_path=datapackage_path,
         metadata_path=metadata_path,
+        filter_tables=requested_tables,
     )
-    table_defs_to_extract = table_defs
-    if requested_tables:
-        table_defs_to_extract = {
-            tn: td for tn, td in table_defs.items() if tn in requested_tables
-        }
 
     instance_builders = [
         ib
@@ -77,7 +73,7 @@ def extract(
 
     table_data, stats = table_data_from_instances(
         instance_builders,
-        table_defs_to_extract,
+        table_defs,
         workers=workers,
         batch_size=batch_size,
     )


### PR DESCRIPTION
This makes it so you can do something like:

```fish
> xbrl_extract $PUDL_INPUT/2021/ferc1-xbrl-2021.zip foo.sqlite --instance-pattern "PJM" --requested-tables "electric_operations_and_maintenance_expenses_320_duration" "identification_001_duration" --metadata-path foo-md.json
```

And take a look-see at what the extractor is putting out, as well as stuff breakpoints in places without having to add conditional breakpoints like "if the table is blah and the instance is blah, then breakpoint()".


Some timings just for fun:

```
> time xbrl_extract $PUDL_INPUT/2021/ferc1-xbrl-2021.zip foo.sqlite --instance-pattern "PJM" --requested-tables "electric_operations_and_maintenance_expenses_320_duration" "identification_001_duration" --metadata-path foo-md.json
2023-09-27 13:01:52 [    INFO] catalystcoop.ferc_xbrl_extractor.xbrl:265 Parsing taxonomy from https://eCollection.ferc.gov/taxonomy/form1/2022-01-01/form/form1/form-1_2022-01-01.xsd
2023-09-27 13:01:56 [    INFO] catalystcoop.ferc_xbrl_extractor.xbrl:149 Finished batch 1/1

________________________________________________________
Executed in    5.89 secs    fish           external
   usr time    7.20 secs    0.31 millis    7.20 secs
   sys time    2.07 secs    1.75 millis    2.07 secs

```