### PR TITLE
Suppress warnings with 'ignore' not 'once' becuase 'once' doesn't work.

### DIFF
--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -128,7 +128,13 @@ def table_data_from_instances(
             for instance_name, fact_ids in batch["metadata"].items():
                 results["metadata"][instance_name] |= fact_ids
 
-        filings = {table: pd.concat(dfs) for table, dfs in results["dfs"].items()}
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                action="ignore",
+                category=FutureWarning,
+                message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated",
+            )
+            filings = {table: pd.concat(dfs) for table, dfs in results["dfs"].items()}
         metadata = results["metadata"]
         return filings, metadata
 
@@ -169,8 +175,7 @@ def process_batch(
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            action="once",
-            module="ferc_xbrl_extractor.xbrl",
+            action="ignore",
             category=FutureWarning,
             message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.",
         )


### PR DESCRIPTION
After much experimentation, it sure seems like

```py
warnings.filterwarnings(action="once")
```

just doesn't filter the warnings at all.  I tried doing it at the module level, and with a context manager, with the modules specified or not. I tried using `action="module"` and that also had no effect.  Only `action="ignore"` seems to make the tens of thousands of warnings go away, so I did it with as narrow a scope as possible.

