### PR TITLE
Add retries to taxonomy reading.

### DIFF
--- a/tests/integration/arelle_interface_test.py
+++ b/tests/integration/arelle_interface_test.py
@@ -1,0 +1,21 @@
+import concurrent.futures
+from unittest.mock import patch
+
+from arelle import Cntlr
+
+from ferc_xbrl_extractor.arelle_interface import load_taxonomy
+
+
+def test_concurrent_taxonomy_load(tmp_path):
+    cntlr = Cntlr.Cntlr()
+    cntlr.webCache.cacheDir = str(tmp_path)
+    cntlr.webCache.clear()
+    path = "https://eCollection.ferc.gov/taxonomy/form60/2022-01-01/form/form60/form-60_2022-01-01.xsd"
+    with patch("ferc_xbrl_extractor.arelle_interface.Cntlr.Cntlr", lambda: cntlr):
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(load_taxonomy, path) for _ in range(2)]
+        done, _not_done = concurrent.futures.wait(
+            futures, timeout=10, return_when=concurrent.futures.ALL_COMPLETED
+        )
+    errored = {fut for fut in done if fut.exception()}
+    assert len(errored) == 0


### PR DESCRIPTION
# Overview

Addresses catalyst-cooperative/pudl#3449 

What problem does this address?

When we try to load a taxonomy multiple times concurrently, we run into `FileExistsError`s as the various threads try to cache files at the same location.

What did you change in this PR?

I made us retry the taxonomy read if the cache is confused.

I also added a surprisingly hard-to-write test that runs these taxonomy reads in parallel.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

```[tasklist]
- [ ] after merge: need to push a `v1.3.3` tag
- [ ] depend on new version in `pudl`
```
