### PR TITLE
Update to Frictionless v5 and make the tests pass.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: ferc-xbrl-extractor
 channels:
   - conda-forge
-  - defaults
 dependencies:
   # Packages required for setting up the environment
   - pip>=21.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = { file = "LICENSE.txt" }
 dependencies = [
     "arelle-release>=2.3,<3",
     "coloredlogs>=14.0,<15.1",
-    "frictionless>=4.4,<5",
+    "frictionless>=5,<6",
     "lxml>=4.9.1,<6",
     "numpy>=1.16,<2",
     "pandas>=1.5,<3",

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -256,11 +256,10 @@ def get_fact_tables(
 
     if datapackage_path:
         # Verify that datapackage descriptor is valid before outputting
-        frictionless_package = Package(descriptor=datapackage.model_dump(by_alias=True))
-        if not frictionless_package.metadata_valid:
-            raise RuntimeError(
-                f"Generated datapackage is invalid - {frictionless_package.metadata_errors}"
-            )
+        report = Package.validate_descriptor(datapackage.model_dump(by_alias=True))
+
+        if not report.valid:
+            raise RuntimeError(f"Generated datapackage is invalid - {report.errors}")
 
         # Write to JSON file
         with Path(datapackage_path).open(mode="w") as f:

--- a/tests/integration/datapackage_test.py
+++ b/tests/integration/datapackage_test.py
@@ -39,7 +39,7 @@ def test_datapackage_generation(test_dir):
     # test than a normative statement
     assert len(all_tables) == 366
 
-    assert Package(descriptor=datapackage.model_dump(by_alias=True)).metadata_valid
+    assert Package.validate_descriptor(datapackage.model_dump(by_alias=True))
 
 
 def _create_schema(instant=True, axes=None):


### PR DESCRIPTION
# Overview

* Bump the version of the `frictionless` package to v5 and make the few changes required to get the tests passing.
* A step step toward https://github.com/catalyst-cooperative/pudl/issues/3293

# Testing

* I installed this branch in the main PUDL repo locally and was able to run `make test-coverage` successfully, which extracts the FERC XBRL data.