### PR TITLE
Update README.rst to fix tox-pytest badge link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ FERC XBRL Extractor
    :target: https://www.repostatus.org/#active
    :alt: Project Status: Active
 
-.. image:: https://github.com/catalyst-cooperative/ferc-xbrl-extractor/workflows/tox-pytest/badge.svg
+.. image:: https://github.com/catalyst-cooperative/ferc-xbrl-extractor/actions/workflows/tox-pytest.yml/badge.svg
    :target: https://github.com/catalyst-cooperative/ferc-xbrl-extractor/actions/workflows/tox-pytest.yml
    :alt: Tox-PyTest Status
 


### PR DESCRIPTION
# Overview

Closes #159.

What problem does this address?
We're using the wrong link for the `tox-pytest` test badge. Updated to the correct link. The README should now show a passing badge.

What did you change in this PR?
Fixed the URL for the image.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Check the URL where the image is located. It should be a "passing" tox-pytest badge.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
