### PR TITLE
Allow Python 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Build source and wheel distributions
         run: |
           python -m pip install --upgrade build twine

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   # Formatters: hooks that re-write Python and RST files
   ########################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.11.5
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,9 @@ channels:
   - conda-forge
 dependencies:
   # Packages required for setting up the environment
-  - pip>=21.0
-  - python>=3.10,<3.13
-  - setuptools>=66
+  - pip>=25.0
+  - python>=3.10,<3.14
+  - setuptools>=75
 
   # XBRL parsing library
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Catalyst Cooperative", email = "pudl@catalyst.coop" },
     { name = "Zach Schira", email = "zach.schira@catalyst.coop" },
 ]
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dynamic = ["version"]
 license = { file = "LICENSE.txt" }
 dependencies = [
@@ -37,6 +37,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 keywords = [
     "accounting",
@@ -102,7 +103,7 @@ where = ["src"]
 
 [tool.ruff]
 # Configurations that apply to both the `format` and `lint` subcommands.
-target-version = "py312"
+target-version = "py313"
 line-length = 88
 indent-width = 4
 


### PR DESCRIPTION
# Overview

Update testing and dependencies to allow Python 3.13 to see if it works -- so that this package doesn't hold back PUDL when our other dependencies allow Python 3.13

- Updated `pyproject.toml` dependencies
- Updated package metadata
- Updated target linting version to py313
- Updated GitHub Actions workflow files to use Python 3.13 environment.
- Added Python 3.13 to the CI testing matrix.
- Updated ruff linter pre-commit hook to 0.11.5

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have