### PR TITLE
Make table name pattern more robust

### DIFF
--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -139,7 +139,7 @@ CONVERT_DTYPES: dict[str, Callable] = {
 Map callables to schema field type to convert parsed values (Data Package `field.type`).
 """
 
-TABLE_NAME_PATTERN = re.compile("(.+)\s+-\s+Schedule\s+-\s+(.*)", re.I)  # noqa: W605, FS003
+TABLE_NAME_PATTERN = re.compile("(.+)\s+-\s+Schedule\s+-\s+(.*)", re.I)  # noqa: W605
 """
 Simple regex pattern used to clean up table names.
 """
@@ -226,6 +226,9 @@ def clean_table_names(name: str) -> str | None:
     name = _lowercase_words(name)
     m = TABLE_NAME_PATTERN.match(name)
     if not m:
+        # Some taxnomies have a table that lists deprecated items. Ignore these tables
+        if "Deprecated" in name:
+            return None
         raise RuntimeError(f"Error could not parse table name: '{name}'.")
 
     # Rearrange name to be {table_name}_{page_number}

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -139,7 +139,7 @@ CONVERT_DTYPES: dict[str, Callable] = {
 Map callables to schema field type to convert parsed values (Data Package `field.type`).
 """
 
-TABLE_NAME_PATTERN = re.compile("(.+) - Schedule - (.*)")  # noqa: W605, FS003
+TABLE_NAME_PATTERN = re.compile("(.+)\s+-\s+Schedule\s+-\s+(.*)", re.I)  # noqa: W605, FS003
 """
 Simple regex pattern used to clean up table names.
 """
@@ -226,7 +226,7 @@ def clean_table_names(name: str) -> str | None:
     name = _lowercase_words(name)
     m = TABLE_NAME_PATTERN.match(name)
     if not m:
-        return None
+        raise RuntimeError(f"Error could not parse table name: '{name}'.")
 
     # Rearrange name to be {table_name}_{page_number}
     table_name = f"{m.group(2)}_{m.group(1)}"

--- a/tests/integration/data_quality_test.py
+++ b/tests/integration/data_quality_test.py
@@ -44,19 +44,9 @@ def test_lost_facts_pct(extracted, request):
     )
     used_fact_ratio = total_used_facts / total_facts
 
-    if "form6_" in request.node.name:
-        # We have unallocated data for Form 6 for some reason.
-        total_threshold = 0.9
-        per_filing_threshold = 0.8
-        # Assert that this is < 0.97 so we remember to fix this test once we
-        # fix the bug. We don't use xfail here because the parametrization is
-        # at the *fixture* level, and only the lost facts tests should fail
-        # for form 6.
-        assert used_fact_ratio > total_threshold and used_fact_ratio <= 0.97
-    else:
-        total_threshold = 0.99
-        per_filing_threshold = 0.95
-        assert used_fact_ratio > total_threshold and used_fact_ratio <= 1
+    total_threshold = 0.99
+    per_filing_threshold = 0.95
+    assert used_fact_ratio > total_threshold and used_fact_ratio <= 1
 
     for instance_stats in stats.values():
         instance_used_ratio = (


### PR DESCRIPTION
# Overview

Closes [4203](https://github.com/catalyst-cooperative/pudl/issues/4203).

What problem does this address?
This PR fixes an issue where select tables in the FERC form 6 taxonomy where not being extracted because the names of the tables did not conform to our expected pattern.

### What did you change in this PR?

I made the pattern we use to parse and reformat table names less restrictive to work with these tables. I've also made it raise an error if we encounter tables we can't parse, so in the future we won't quietly miss any tables as we have been in this case.

# Testing

I've re-run the extraction of ferc 6 data and verified the missing table is now being extracted as expected. I've attached the output sqlite db here: [ferc6-xbrl.sqlite.zip](https://github.com/user-attachments/files/19872211/ferc6-xbrl.sqlite.zip).


