### PR TITLE
Output to duckdb and sqlite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ filings, use the command:
 
 .. code-block:: console
 
-    $ xbrl_extract examples/ferc1-2021-sample.zip --db-path ./ferc1-2021-sample.sqlite \
+    $ xbrl_extract examples/ferc1-2021-sample.zip --sqlite-path ./ferc1-2021-sample.sqlite \
         --taxonomy examples/ferc1-xbrl-taxonomies.zip
 
 The tool expects the ``--taxonomy`` option to point to a zipfile containing archived
@@ -144,7 +144,7 @@ batches of 50 filings at a time.
 
 .. code-block:: console
 
-    $ xbrl_extract examples/ferc1-2021-sample.zip .--db-path /ferc1-2021-sample.sqlite \
+    $ xbrl_extract examples/ferc1-2021-sample.zip .--sqlite-path /ferc1-2021-sample.sqlite \
         --taxonomy examples/ferc1-xbrl-taxonomies.zip
         --workers 5 \
         --batch-size 50
@@ -160,7 +160,7 @@ filings and taxonomy, run the following command.
 
 .. code-block:: console
 
-    $ xbrl_extract examples/ferc1-2021-sample.zip .--db-path /ferc1-2021-sample.sqlite \
+    $ xbrl_extract examples/ferc1-2021-sample.zip .--sqlite-path /ferc1-2021-sample.sqlite \
         --taxonomy examples/ferc1-xbrl-taxonomies.zip
         --metadata-path metadata.json \
         --datapackage-path datapackage.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ license = { file = "LICENSE.txt" }
 dependencies = [
     "arelle-release>=2.3,<3",
     "coloredlogs>=14.0,<15.1",
+    "duckdb>=1.3.2",
     "frictionless>=5,<6",
     "lxml>=4.9.1,<7",
     "numpy>=1.16,<3",


### PR DESCRIPTION
# Overview

This PR updates XBRL extractor to output to duckdb as well as SQLite. The purpose of this change is to make the raw FERC XBRL data available in Eel Hole.

I had initially started working on an update to only output duckdb, but this requires updating all places in PUDL where we access the SQLite files. This isn't too difficult, as we can switch the extraction to pull from the new duckdb files, but considering this touches the nightly builds, CI, and local development, it will be easier to just output both for now, and we can eventually fully deprecate the SQLite output.

# Testing

I executed the example command in the `README`, but added an option to also output duckdb.

`xbrl_extract examples/ferc1-2021-sample.zip -t examples/ferc1-xbrl-taxonomies.zip -f 6 --duckdb-path ferc1.duckdb --sqlite-path ferc1.sqlite`


