### PR TITLE
Update arelle pin to avoid pillow v12.0 issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ authors = [
     { name = "Catalyst Cooperative", email = "pudl@catalyst.coop" },
     { name = "Zach Schira", email = "zach.schira@catalyst.coop" },
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.14.0a0"
 dynamic = ["version"]
 license = { file = "LICENSE.txt" }
 dependencies = [
-    "arelle-release>=2.3,<3",
+    "arelle-release>=2.32,<3",
     "coloredlogs>=14.0,<15.1",
     "duckdb>=1.3.2",
     "frictionless>=5,<6",


### PR DESCRIPTION
# Overview

* `pillow` v12.0.0 was recently released, and is prohibited by Arelle for the time being.
* However, that prohibition only shows up in the Arelle dependencies starting in version 2.32.
* We have a very old minimum Arelle version of 2.3 which means that our environment solves are now trying to give us a new `pillow` and a very old `Arelle` which isn't really what we want.
* This PR bumps the minimum allowed version of Arelle to be 2.32 to avoid this problem without us needing to pin `pillow` elsewhere, when we don't actually rely on it directly.

# Testing

* Ran the CI tests here on GitHub


