### PR TITLE
Load XBRL to parquet files 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,22 +186,18 @@ batches of 50 filings at a time. It will also output both SQLite and DuckDB.
         --workers 5 \
         --batch-size 50
 
-There are also several options included for extracting metadata from the taxonomy.
-First is the ``--datapackage-path`` command to save a
-`frictionless datapackage <https://specs.frictionlessdata.io/data-package/>`__
-descriptor as JSON, which annotates the generated SQLite database. There is also the
-``--metadata-path`` option, which writes more extensive taxonomy metadata to a json
-file, grouped by table name. See the ``ferc_xbrl_extractor.arelle_interface`` module
-for more info on the extracted metadata. To create both of these files using the example
-filings and taxonomy, run the following command.
+You can also pass the ``--metadata-path`` option,
+which writes extensive taxonomy metadata to a json file,
+grouped by table name.
+See the ``ferc_xbrl_extractor.arelle_interface`` module for more info on the extracted metadata.
+
 
 .. code-block:: bash
 
     xbrl_extract examples/ferc1-2021-sample.zip \
         --sqlite-path /ferc1-2021-sample.sqlite \
         --taxonomy examples/ferc1-xbrl-taxonomies.zip \
-        --metadata-path metadata.json \
-        --datapackage-path datapackage.json
+        --metadata-path metadata.json
 
 Contributing / Development
 --------------------------

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -190,7 +190,6 @@ def run_main(
 
 def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
     """Convert the duckdb into a directory of parquet files."""
-    print(duckdb_path)
     con = duckdb.connect(duckdb_path)
     tables = con.sql("SHOW TABLES").fetchall()
     # tables is a list of tuples, so condense the list

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -29,13 +29,11 @@ def parse():
     )
     parser.add_argument(
         "--sqlite-path",
-        default="ferc-xbrl.sqlite",
         help="Path to SQLite DB to write extracted XBRL data.",
         type=Path,
     )
     parser.add_argument(
         "--duckdb-path",
-        default=None,
         help="Path to DuckDB DB to write extracted XBRL data.",
         type=Path,
     )
@@ -69,7 +67,6 @@ def parse():
     parser.add_argument(
         "-f",
         "--form-number",
-        default=1,
         type=int,
         help="Specify form number to choose taxonomy used to generate output schema (if a taxonomy is explicitly specified that will override this parameter). Form number is also used for setting the name of the datapackage descriptor if requested.",
     )
@@ -140,8 +137,8 @@ def run_main(
     filings: list[Path] | list[io.BytesIO],
     taxonomy: str | Path | io.BytesIO,
     sqlite_path: Path,
-    duckdb_path: Path | None,
-    form_number: int | None,
+    duckdb_path: Path,
+    form_number: int,
     metadata_path: Path | None,
     datapackage_path: Path | None,
     workers: int | None,
@@ -164,10 +161,19 @@ def run_main(
         file_logger.setFormatter(logging.Formatter(log_format))
         logger.addHandler(file_logger)
 
+    # NOTE 2026-04-30: This would flow much better overall if extract was split into two steps:
+    #
+    # 1. extract taxonomy and metadata
+    # 2. read data in from xbrl
+    #
+    # Then we can do the loading and writing of datapackage.jsons out at the end.
+    #
+    # CG/DX did not have time or gumption for this refactor but think it would
+    # make this easier to work with.
     extracted = xbrl.extract(
         taxonomy_source=taxonomy,
         form_number=form_number,
-        db_uri=sqlite_uri,
+        db_uri=sqlite_path.absolute().name,
         datapackage_path=datapackage_path,
         metadata_path=metadata_path,
         filings=filings,
@@ -178,6 +184,16 @@ def run_main(
     )
     # Save extracted data in SQLite/duckdb
     load_extracted(extracted, sqlite_uri, duckdb_path)
+
+    load_parquet(form_number, datapackage_path, duckdb_path)
+
+
+def load_parquet(form_number, datapackage_path, duckdb_path):
+    # read tables from duckdb
+    # dump to parquet, at Path(f"ferc{form_number}_xbrl") / table_name
+    # read existing datapackage
+    # update paths, remove the dialect, change format + mediatype
+    pass
 
 
 def main():

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -223,12 +223,14 @@ def write_validated_datapackage(datapackage: dict, parquet_dir: Path):
 
 def load_parquet(form_number, datapackage_path, output_path, duckdb_path):
     """Convert duckdb and existing datapacakge into parquet."""
+    parquet_dir = output_path / f"ferc{form_number}_xbrl"
+    convert_duckdb_into_parquet(duckdb_path, parquet_dir)
     # read existing datapackage
-    with open(datapackage_path) as file:
+    with Path(datapackage_path).open() as file:
         datapackage = json.load(file)
 
     datapackage = convert_datapackge_sqlite_to_parquet(datapackage)
-    write_validated_datapackage(datapackage)
+    write_validated_datapackage(datapackage, parquet_dir)
 
 
 def main():

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -181,7 +181,9 @@ def run_main(
 
     parquet_dir = output_dir / f"ferc{form_number}_xbrl"
     convert_duckdb_into_parquet(duckdb_path, parquet_dir)
-    datapackage_parquet = convert_and_validate_datapackage_sqlite_to_parquet()
+    datapackage_parquet = convert_and_validate_datapackage_sqlite_to_parquet(
+        datapackage_path
+    )
     write_datapackage(datapackage_parquet, parquet_dir)
 
 

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -181,19 +181,22 @@ def run_main(
     load_extracted(extracted, sqlite_uri, duckdb_path)
 
     parquet_dir = output_dir / f"ferc{form_number}_xbrl"
-    convert_duckdb_into_parquet(duckdb_path, parquet_dir)
+    convert_duckdb_into_parquet(duckdb_path=duckdb_path, parquet_dir=parquet_dir)
     datapackage_parquet = convert_and_validate_datapackage_sqlite_to_parquet(
-        datapackage_path
+        datapackage_path=datapackage_path
     )
-    write_datapackage(datapackage_parquet, parquet_dir)
+    write_datapackage(datapackage=datapackage_parquet, output_dir=parquet_dir)
 
 
 def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
     """Convert the duckdb into a directory of parquet files."""
+    print(duckdb_path)
     con = duckdb.connect(duckdb_path)
     tables = con.sql("SHOW TABLES").fetchall()
     # tables is a list of tuples, so condense the list
     tables = chain.from_iterable(tables)
+    if not parquet_dir.exists():
+        parquet_dir.mkdir(exist_ok=True)
     for table in tables:
         con.execute(
             f"COPY {table} TO '{parquet_dir}/{table}.parquet' (FORMAT parquet);"

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import io
+import json
 import logging
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ from pathlib import Path
 import coloredlogs
 import duckdb
 import pandas as pd
+from frictionless import Package
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
@@ -188,12 +190,45 @@ def run_main(
     load_parquet(form_number, datapackage_path, duckdb_path)
 
 
-def load_parquet(form_number, datapackage_path, duckdb_path):
-    # read tables from duckdb
-    # dump to parquet, at Path(f"ferc{form_number}_xbrl") / table_name
-    # read existing datapackage
+def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
+    """Convert the duckdb into a directory of parquet files."""
+    con = duckdb.connect(duckdb_path)
+    con.execute(f"EXPORT DATABASE '{str(parquet_dir)}' (FORMAT PARQUET);")
+
+
+def convert_datapackge_sqlite_to_parquet(datapackage: dict) -> dict:
+    """Convert the datapackage made for the SQLite files."""
     # update paths, remove the dialect, change format + mediatype
-    pass
+    for resource in datapackage["resources"]:
+        name = resource["name"]
+        resource["path"] = f"{name}.parquet"
+        resource["format"] = "parquet"
+        resource["mediatype"] = "application/vnd.apache.parquet"
+        resource.pop("dialect")
+
+    return datapackage
+
+
+def write_validated_datapackage(datapackage: dict, parquet_dir: Path):
+    """Validate and write datapackage."""
+    # Verify that datapackage descriptor is valid before outputting
+    report = Package.validate_descriptor(datapackage)
+    if not report.valid:
+        raise RuntimeError(f"Generated datapackage is invalid - {report.errors}")
+
+    # Write to JSON file
+    with Path(parquet_dir / "datapackage.json").open(mode="w") as f:
+        f.write(json.dumps(datapackage, indent=2))
+
+
+def load_parquet(form_number, datapackage_path, output_path, duckdb_path):
+    """Convert duckdb and existing datapacakge into parquet."""
+    # read existing datapackage
+    with open(datapackage_path) as file:
+        datapackage = json.load(file)
+
+    datapackage = convert_datapackge_sqlite_to_parquet(datapackage)
+    write_validated_datapackage(datapackage)
 
 
 def main():

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -189,7 +189,12 @@ def run_main(
 
 
 def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
-    """Convert the duckdb into a directory of parquet files."""
+    """Convert the duckdb into a directory of parquet files.
+
+    We do this using COPY. We tried using EXPORT DATABASE, but it unfortunately
+    sanitizes the table names, which removes the schedule numbers in the table
+    names so we can't use it.
+    """
     con = duckdb.connect(duckdb_path)
     tables = con.sql("SHOW TABLES").fetchall()
     # tables is a list of tuples, so condense the list
@@ -200,24 +205,24 @@ def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
         con.execute(
             f"COPY {table} TO '{parquet_dir}/{table}.parquet' (FORMAT parquet);"
         )
-    # unfortunately export database sanitizes the table names, which removes the
-    # schedule numbers in the table names so we can't use it.
-    # con.execute(f"EXPORT DATABASE '{str(parquet_dir)}' (FORMAT PARQUET);")
 
 
 def convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path: Path) -> dict:
-    """Convert the datapackage made for the SQLite files."""
+    """Convert the SQLite datapackage into one that points at Parquet files.
+
+    * instead of ``path`` pointing at monolithic SQLite db, point at individual Parquet files instead
+    * update format/metadata fields
+    * remove irrelevant dialect field
+    """
     # read existing datapackage
     with Path(datapackage_path).open() as file:
         datapackage = json.load(file)
-    # update paths, remove the dialect, change format + mediatype
     for resource in datapackage["resources"]:
         name = resource["name"]
         resource["path"] = f"{name}.parquet"
         resource["format"] = "parquet"
         resource["mediatype"] = "application/vnd.apache.parquet"
         resource.pop("dialect")
-
     # Verify that datapackage descriptor is valid before outputting
     report = Package.validate_descriptor(datapackage)
     if not report.valid:
@@ -226,8 +231,10 @@ def convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path: Path) -
 
 
 def write_datapackage(datapackage: dict, output_dir: Path):
-    """Write datapackage."""
-    # Write to JSON file
+    """Write a datapackage to <output_dir>/datapackage.json.
+
+    output_dir must exist.
+    """
     with Path(output_dir / "datapackage.json").open(mode="w") as f:
         f.write(json.dumps(datapackage, indent=2))
 

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import sys
+from itertools import chain
 from pathlib import Path
 
 import coloredlogs
@@ -190,7 +191,16 @@ def run_main(
 def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
     """Convert the duckdb into a directory of parquet files."""
     con = duckdb.connect(duckdb_path)
-    con.execute(f"EXPORT DATABASE '{str(parquet_dir)}' (FORMAT PARQUET);")
+    tables = con.sql("SHOW TABLES").fetchall()
+    # tables is a list of tuples, so condense the list
+    tables = chain.from_iterable(tables)
+    for table in tables:
+        con.execute(
+            f"COPY {table} TO '{parquet_dir}/{table}.parquet' (FORMAT parquet);"
+        )
+    # unfortunately export database sanitizes the table names, which removes the
+    # schedule numbers in the table names so we can't use it.
+    # con.execute(f"EXPORT DATABASE '{str(parquet_dir)}' (FORMAT PARQUET);")
 
 
 def convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path: Path) -> dict:

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -30,6 +30,11 @@ def parse():
         type=Path,
     )
     parser.add_argument(
+        "--output-dir",
+        help="Path to output directory where parquet directory will end up.",
+        type=Path,
+    )
+    parser.add_argument(
         "--sqlite-path",
         help="Path to SQLite DB to write extracted XBRL data.",
         type=Path,
@@ -38,13 +43,6 @@ def parse():
         "--duckdb-path",
         help="Path to DuckDB DB to write extracted XBRL data.",
         type=Path,
-    )
-    parser.add_argument(
-        "-s",
-        "--datapackage-path",
-        default=None,
-        type=Path,
-        help="Generate frictionless datapackage descriptor, and write to JSON file at specified path.",
     )
     parser.add_argument(
         "-b",
@@ -71,13 +69,6 @@ def parse():
         "--form-number",
         type=int,
         help="Specify form number to choose taxonomy used to generate output schema (if a taxonomy is explicitly specified that will override this parameter). Form number is also used for setting the name of the datapackage descriptor if requested.",
-    )
-    parser.add_argument(
-        "-m",
-        "--metadata-path",
-        default=None,
-        type=Path,
-        help="Specify path to output metadata extracted taxonomy. Metadata will not be extracted if no path is specified.",
     )
     parser.add_argument(
         "--loglevel",
@@ -138,11 +129,10 @@ def load_extracted(
 def run_main(
     filings: list[Path] | list[io.BytesIO],
     taxonomy: str | Path | io.BytesIO,
+    output_dir: Path,
     sqlite_path: Path,
     duckdb_path: Path,
     form_number: int,
-    metadata_path: Path | None,
-    datapackage_path: Path | None,
     workers: int | None,
     batch_size: int | None,
     loglevel: str,
@@ -157,6 +147,8 @@ def run_main(
     coloredlogs.install(fmt=log_format, level=loglevel, logger=logger)
 
     sqlite_uri = f"sqlite:///{sqlite_path.absolute()}"
+    datapackage_path = output_dir / f"ferc{form_number}_xbrl_datapackage.json"
+    metadata_path = output_dir / f"ferc{form_number}_xbrl_taxonomy_metadata.json"
 
     if logfile:
         file_logger = logging.FileHandler(logfile)
@@ -187,7 +179,10 @@ def run_main(
     # Save extracted data in SQLite/duckdb
     load_extracted(extracted, sqlite_uri, duckdb_path)
 
-    load_parquet(form_number, datapackage_path, duckdb_path)
+    parquet_dir = output_dir / f"ferc{form_number}_xbrl"
+    convert_duckdb_into_parquet(duckdb_path, parquet_dir)
+    datapackage_parquet = convert_and_validate_datapackage_sqlite_to_parquet()
+    write_datapackage(datapackage_parquet, parquet_dir)
 
 
 def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
@@ -196,8 +191,11 @@ def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
     con.execute(f"EXPORT DATABASE '{str(parquet_dir)}' (FORMAT PARQUET);")
 
 
-def convert_datapackge_sqlite_to_parquet(datapackage: dict) -> dict:
+def convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path: Path) -> dict:
     """Convert the datapackage made for the SQLite files."""
+    # read existing datapackage
+    with Path(datapackage_path).open() as file:
+        datapackage = json.load(file)
     # update paths, remove the dialect, change format + mediatype
     for resource in datapackage["resources"]:
         name = resource["name"]
@@ -206,31 +204,18 @@ def convert_datapackge_sqlite_to_parquet(datapackage: dict) -> dict:
         resource["mediatype"] = "application/vnd.apache.parquet"
         resource.pop("dialect")
 
-    return datapackage
-
-
-def write_validated_datapackage(datapackage: dict, parquet_dir: Path):
-    """Validate and write datapackage."""
     # Verify that datapackage descriptor is valid before outputting
     report = Package.validate_descriptor(datapackage)
     if not report.valid:
         raise RuntimeError(f"Generated datapackage is invalid - {report.errors}")
+    return datapackage
 
+
+def write_datapackage(datapackage: dict, output_dir: Path):
+    """Write datapackage."""
     # Write to JSON file
-    with Path(parquet_dir / "datapackage.json").open(mode="w") as f:
+    with Path(output_dir / "datapackage.json").open(mode="w") as f:
         f.write(json.dumps(datapackage, indent=2))
-
-
-def load_parquet(form_number, datapackage_path, output_path, duckdb_path):
-    """Convert duckdb and existing datapacakge into parquet."""
-    parquet_dir = output_path / f"ferc{form_number}_xbrl"
-    convert_duckdb_into_parquet(duckdb_path, parquet_dir)
-    # read existing datapackage
-    with Path(datapackage_path).open() as file:
-        datapackage = json.load(file)
-
-    datapackage = convert_datapackge_sqlite_to_parquet(datapackage)
-    write_validated_datapackage(datapackage, parquet_dir)
 
 
 def main():

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -56,18 +56,17 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
     with the example filings and taxonomy in the ``examples/`` directory, and verify
     that it returns successfully.
     """
+    form_number = 1
     output_dir = tmp_path
-    sqlite_path = tmp_path / "ferc1-2021-sample.sqlite"
-    duckdb_path = tmp_path / "ferc1-2021-sample.duckdb"
+    sqlite_path = tmp_path / f"ferc{form_number}-2021-sample.sqlite"
+    duckdb_path = tmp_path / f"ferc{form_number}-2021-sample.duckdb"
     log_file = tmp_path / "log.log"
     data_dir = test_dir / "integration" / "data"
 
     ret = script_runner.run(
         [
             "xbrl_extract",
-            str(data_dir / "ferc1-xbrl-2021.zip"),
-            "--form-number",
-            1,
+            str(data_dir / f"ferc{form_number}-xbrl-2021.zip"),
             "--output-dir",
             str(output_dir),
             "--sqlite-path",
@@ -75,7 +74,9 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
             "--duckdb-path",
             str(duckdb_path),
             "--taxonomy",
-            str(data_dir / "ferc1-xbrl-taxonomies.zip"),
+            str(data_dir / f"ferc{form_number}-xbrl-taxonomies.zip"),
+            "--form-number",
+            1,
             "--logfile",
             str(log_file),
         ]

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -56,10 +56,9 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
     with the example filings and taxonomy in the ``examples/`` directory, and verify
     that it returns successfully.
     """
+    output_dir = tmp_path
     sqlite_path = tmp_path / "ferc1-2021-sample.sqlite"
     duckdb_path = tmp_path / "ferc1-2021-sample.duckdb"
-    metadata = tmp_path / "metadata.json"
-    datapackage = tmp_path / "datapackage.json"
     log_file = tmp_path / "log.log"
     data_dir = test_dir / "integration" / "data"
 
@@ -67,16 +66,16 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
         [
             "xbrl_extract",
             str(data_dir / "ferc1-xbrl-2021.zip"),
+            "--form-number",
+            1,
+            "--output-dir",
+            str(output_dir),
             "--sqlite-path",
             str(sqlite_path),
             "--duckdb-path",
             str(duckdb_path),
             "--taxonomy",
             str(data_dir / "ferc1-xbrl-taxonomies.zip"),
-            "--metadata-path",
-            str(metadata),
-            "--datapackage-path",
-            str(datapackage),
             "--logfile",
             str(log_file),
         ]

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -127,7 +127,6 @@ def test_extract_example_filings_bad_form(script_runner, tmp_path, test_dir):
     """
     out_db = tmp_path / "ferc1-2021-sample.sqlite"
     metadata = tmp_path / "metadata.json"
-    datapackage = tmp_path / "datapackage.json"
     log_file = tmp_path / "log.log"
     data_dir = test_dir / "integration" / "data"
 
@@ -140,8 +139,6 @@ def test_extract_example_filings_bad_form(script_runner, tmp_path, test_dir):
             "666",
             "--metadata-path",
             str(metadata),
-            "--datapackage-path",
-            str(datapackage),
             "--logfile",
             str(log_file),
         ]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Related to [eel-hole#66.](https://github.com/catalyst-cooperative/eel-hole/issues/66)

What problem does this address?

What did you change in this PR?
- `run_main` first converts the xbrl data into a sqlite db, then a duck_db...
- and now it also has a small section which converts from duck_db into parquet files and makes a new datapackage associated with the parquet files.
- plus, leave a breadcrumb that indicates the refactor we *wanted* to do but wisely, prudently, in our infinite grace, decided to put off.

some intent:
- we *wanted* many things but prudently (infinite grace) didn't structurally change the rest of how/when/where we process xbrl. to do it all in a super ideal way would have involved some major reordering of processes which would be nice but felt oos/rabbit hole-y.
- now the loading parquet files *requires* duckdb to be output before the parquet bc it converts the duckdb.
- the parquet based datapackage converts the sqlite datapackage
- so there are two dependencies baked into this new parquet process.

output:
within the `output_dir`
- `ferc{#}_xbrl`
   - `{table_name}.parquet` (for all tables in sqlite db)
   - `datapacakge.json`

# Testing

Manual testing plan - can eel-hole use these outputs?:
* [x] serve parquet files from PUDL_OUTPUT, with CORS support:
```python
# Source - https://stackoverflow.com/a/21957017
# Posted by poke, modified by community. See post 'Timeline' for change history
# Retrieved 2026-04-24, License - CC BY-SA 4.0

#!/usr/bin/env python3
from http.server import HTTPServer, SimpleHTTPRequestHandler, test
import sys

class CORSRequestHandler (SimpleHTTPRequestHandler):
    def end_headers (self):
        self.send_header('Access-Control-Allow-Origin', '*')
        SimpleHTTPRequestHandler.end_headers(self)

if __name__ == '__main__':
    test(CORSRequestHandler, HTTPServer, port=int(sys.argv[1]) if len(sys.argv) > 1 else 8000)

```
* [x] point eel-hole index building at localhost datapackage location, and rebuild docker image to get the new index
* [x] (this could be its own eel-hole PR) update the `preview_path`s in `SingletonResourceDisplay`/`PartitionedResourceDisplay` to be based on the location of the datapackage.json - if we know where the datapackage.json is, and we know that the resource path is relative to that, we should be able to pass back a nice data URL.
* [x] try querying in eel-hole! will probably involve another eel-hole PR of template-wiring changing etc.
* [x] investigate network traffic so we see if we are reading the individual parquet files, not whole blobs of them somehow.

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

