### PR TITLE
Don't build resource or table for null instant or duration tables

### DIFF
--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -310,6 +310,7 @@ class Resource(BaseModel):
         cls, fact_table: LinkRole, period_type: str, db_uri: str
     ) -> "Resource" | None:
         """Generate a Resource from a fact table (defined by a LinkRole).
+
         If the fact table is empty, i.e. there are no data columns, return None.
 
         Args:

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -311,6 +311,7 @@ class Resource(BaseModel):
     ) -> "Resource" | None:
         """Generate a Resource from a fact table (defined by a LinkRole).
         If the fact table is empty, i.e. there are no data columns, return None.
+
         Args:
             fact_table: Link role which defines a fact table.
             period_type: Period type of table.

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -308,9 +308,9 @@ class Resource(BaseModel):
     @classmethod
     def from_link_role(
         cls, fact_table: LinkRole, period_type: str, db_uri: str
-    ) -> "Resource":
+    ) -> "Resource" | None:
         """Generate a Resource from a fact table (defined by a LinkRole).
-
+        If the fact table is empty, i.e. there are no data columns, return None.
         Args:
             fact_table: Link role which defines a fact table.
             period_type: Period type of table.

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -2,7 +2,7 @@
 
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Union
 
 import pandas as pd
 import pydantic
@@ -308,7 +308,7 @@ class Resource(BaseModel):
     @classmethod
     def from_link_role(
         cls, fact_table: LinkRole, period_type: str, db_uri: str
-    ) -> "Resource" | None:
+    ) -> Union["Resource", None]:
         """Generate a Resource from a fact table (defined by a LinkRole).
 
         If the fact table is empty, i.e. there are no data columns, return None.

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -323,14 +323,20 @@ class Resource(BaseModel):
 
         name = f"{cleaned_name}_{period_type}"
 
-        return cls(
-            path=db_uri,
-            name=name,
-            dialect=Dialect(table=name),
-            title=f"{fact_table.definition} - {period_type}",
-            description=fact_table.concepts.documentation,
-            schema=Schema.from_concept_tree(fact_table.concepts, period_type),
-        )
+        # check if there are no columns, if none don't make a resource
+        _, columns = _get_fields_from_concepts(fact_table.concepts, period_type)
+        resource_schema = None
+        if columns:
+            resource_schema = cls(
+                path=db_uri,
+                name=name,
+                dialect=Dialect(table=name),
+                title=f"{fact_table.definition} - {period_type}",
+                description=fact_table.concepts.documentation,
+                schema=Schema.from_concept_tree(fact_table.concepts, period_type),
+            )
+
+        return resource_schema
 
     def get_period_type(self):
         """Helper function to get period type from schema."""

--- a/tests/integration/datapackage_test.py
+++ b/tests/integration/datapackage_test.py
@@ -53,9 +53,9 @@ def test_datapackage_generation(test_dir, data_dir):
 
     all_tables = datapackage.get_fact_tables()
 
-    # 366 was just the value we had - this assertion is more of a regression
+    # 255 was just the value we had - this assertion is more of a regression
     # test than a normative statement
-    assert len(all_tables) == 370
+    assert len(all_tables) == 255
 
     assert Package.validate_descriptor(datapackage.model_dump(by_alias=True))
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Working on https://github.com/catalyst-cooperative/eel-hole/issues/66

What problem does this address?
- before we made every instant and duration table. that was fine but we need a way to only display the tables that have any values in them. instead of just removing the tables from the parquet `datapackage.json` I decided to just go upstream and never make them in the first place.

What did you change in this PR?
- when there are no columns, don't make a resource and don't add said resource to the db schema.

# Testing

How did you make sure this worked? How can a reviewer verify this?
- [x] copied an old version of a `datapackage.json` from old all the tables method w/ old all the parquet files
   - [x]  verify that new method is dropping tables
   - [x] verify that new method drops tables that are empty parquet files
- [x] installed editable version of this repo in pudl.
- [x] ran the xbrl assets in the `ferc_to_sqlite` job
- [x] ran the ferc1 transforms w/in pudl and the validation tests...
   - [x]  this did require a small change over in pudl land

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

