### PR TITLE
FIx easy type checking issues and related bugs

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -16,9 +16,9 @@ jobs:
     name: Auto-merge passing bot PRs
     runs-on: ubuntu-latest
     if: >-
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'pre-commit-ci[bot]' ||
-      github.actor == 'catalyst-workflow-triggerer[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'pre-commit-ci[bot]' ||
+      github.event.pull_request.user.login == 'catalyst-workflow-triggerer[bot]'
     steps:
       - name: Impersonate auto merge PR bot
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -40,6 +35,15 @@ jobs:
 
       - name: Install hatch
         run: uv tool install hatch
+
+      # uv manages its own Python distributions rather than relying on the runner's
+      # preinstalled ones (see [tool.uv] in pyproject.toml), so replaces
+      # actions/setup-python. HATCH_PYTHON points Hatch straight at that interpreter,
+      # skipping its own PATH-based discovery.
+      - name: Install Python 3.14 via uv
+        run: |
+          uv python install 3.14
+          echo "HATCH_PYTHON=$(uv python find 3.14)" >> "$GITHUB_ENV"
 
       - name: Build documentation with Sphinx
         run: hatch run docs:build

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -18,16 +18,20 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install hatch
         run: uv tool install hatch
+      # uv manages its own Python distributions rather than relying on the runner's
+      # preinstalled ones (see [tool.uv] in pyproject.toml), so replaces
+      # actions/setup-python. HATCH_PYTHON points Hatch straight at that interpreter,
+      # skipping its own PATH-based discovery.
+      - name: Install Python ${{ matrix.python-version }} via uv
+        run: |
+          uv python install ${{ matrix.python-version }}
+          echo "HATCH_PYTHON=$(uv python find ${{ matrix.python-version }})" >> "$GITHUB_ENV"
       - name: Log environment details
         run: |
           uv --version
@@ -53,16 +57,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.14"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install hatch
         run: uv tool install hatch
+      - name: Install Python 3.14 via uv
+        run: |
+          uv python install 3.14
+          echo "HATCH_PYTHON=$(uv python find 3.14)" >> "$GITHUB_ENV"
       - name: Run linters
         run: |
           hatch run lint:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,6 @@ jobs:
             echo "::error::Tag ${{ github.ref_name }} (${{ github.sha }}) does not point at the current HEAD of main ($main_sha). Pull the latest main and re-tag."
             exit 1
           fi
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.13"
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Build source and wheel distributions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,18 @@ considering a change complete, and `hatch run lint:format` if it touched Python 
 
 ## Gotchas
 
+- Hatch environments use `installer = "uv"` and pin `python = "3.14"`, but Hatch still
+    resolves *which* concrete interpreter satisfies that pin itself, by searching
+    `PATH` (or falling back to its own separate, uv-independent Python distribution
+    manager) -- it does not consult `[tool.uv]`'s `python-preference`. If you have
+    multiple 3.14.x installs around (Homebrew, uv-managed, etc.), Hatch can silently
+    pick a stale one. To force it to use a specific uv-managed interpreter, set the
+    `HATCH_PYTHON` environment variable to that interpreter's path, e.g.
+    `HATCH_PYTHON="$(uv python find 3.14)" hatch run test:all` -- this is what CI does
+    in `.github/workflows/*.yml`, and is worth doing locally too after upgrading the
+    Python version via `uv python install`/`uv python pin`. Follow with
+    `hatch env prune` to drop any environments already built against the old
+    interpreter.
 - The `hatch run lint:*` environment (`[tool.hatch.envs.lint]`) is `detached = true`
     for speed -- it does *not* install this package or its runtime dependencies, only
     `ruff` and friends. That's fine for `ruff`, which only needs to parse syntax, but

--- a/README.rst
+++ b/README.rst
@@ -152,8 +152,13 @@ This tool can be used as a library, as it is in `PUDL
 <https://github.com/catalyst-cooperative/pudl>`__. There is also a CLI provided for
 interacting with XBRL data. The only required options for the CLI are a path to the
 filings to be extracted, and a path to the output database. The path to the
-filings can point to a directory full of XBRL Filings, a single XBRL filing, or a
-zipfile with XBRL filings. If the specified output database already exists, it will be
+filings must point to a zipfile of XBRL filings, or a directory of already-unzipped
+filings that still includes the ``rssfeed`` metadata file FERC's archiving process
+bundles into the zip alongside the filings (useful for local debugging, where it's
+convenient to edit filings directly rather than repackaging them into a zip after
+every change). Each filing's publication time and taxonomy version are derived
+from that file, so a single bare filing with no ``rssfeed`` of its own isn't
+supported. If the specified output database already exists, it will be
 overwritten.
 
 .. code-block:: bash

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -67,6 +67,24 @@ Fix ``get_instances()`` input handling
   input types now raise a clear ``ValueError`` on invalid input instead of
   crashing.
 
+Test suite cleanup
+^^^^^^^^^^^^^^^^^^^
+
+* **Removed the long-dead ``XBRLType.get_pandas_type()`` method.** It was
+  introduced alongside a pandas-DataFrame-based extraction path that was
+  replaced by the current frictionless-datapackage-based path two weeks
+  later; the cleanup commit at the time removed every caller but missed the
+  method itself, leaving it with no callers in this package, ``pudl``, or
+  ``pudl-archiver`` since 2022. :pr:`444`
+* **Reordered integration tests so the three slowest run first.** Under
+  pytest-xdist's default scheduler, tests are dispatched to workers in
+  collection order; a slow test dispatched late tends to run alone after
+  every other worker has emptied its queue, stretching total wall-clock
+  time. A new ``pytest_collection_modifyitems`` hook in ``tests/conftest.py``
+  sorts ``test_concurrent_taxonomy_load`` and the two slowest
+  ``console_scripts_test.py`` cases to the front of collection so they run
+  in parallel with the rest of the suite instead of at the tail. :pr:`444`
+
 .. _release-v1-10-0:
 
 ---------------------------------------------------------------------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,21 @@ Release Notes
 Modernize tooling and packaging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* **Switched from mypy to ty** for type checking. mypy had been declared as a
+  dependency but never actually wired into CI or pre-commit, so this is the first
+  time type checking is enforced here. Pre-existing type gaps (mostly around
+  ``arelle-release``, which ships without type stubs) are suppressed inline with
+  ``# ty:ignore`` comments pending a follow-up typing cleanup.
+* **Fixed real bugs that adopting ty surfaced**, rather than just suppressing
+  them: wrong return-type annotations on ``Instance.get_facts()`` and
+  ``process_batch()``, several functions typed narrower (``Path``-only) than
+  what they're actually called with, and missing ``None`` checks around
+  ``lxml`` element lookups. Also fixed a real crash this work turned up:
+  ``run_main()`` called ``convert_duckdb_into_parquet()`` unconditionally even
+  when ``--duckdb-path`` was never passed, which crashed with
+  ``duckdb.InvalidInputException`` -- including via the simplest example
+  command in the README. ``--duckdb-path`` now defaults to the sqlite path
+  with a ``.duckdb`` suffix instead.
 * **Switched from pre-commit to prek** as the hook runner, and added several new
   hooks: ``detect-secrets``, ``typos``, ``actionlint``, ``markdownlint-cli2``, and
   ``taplo-format``, among others.
@@ -32,6 +47,25 @@ Modernize tooling and packaging
   before building.
 * Switched release notifications from Slack to Zulip. :pr:`434`
 * Routine dependency and GitHub Actions version bumps.
+
+Fix ``get_instances()`` input handling
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Fixed a long-standing crash in ``get_instances()``'s directory and bare-file
+  input modes**, and removed the bare-file mode, which can't be fixed. Both had
+  always crashed with a confusing ``TypeError``: they never supplied the
+  ``InstanceBuilder`` constructor with a filing's publication time and taxonomy
+  version, which are otherwise derived from an ``rssfeed`` metadata file FERC's
+  archiving process bundles into zip archives alongside the filings. Adopting
+  ``ty`` for type checking surfaced the bug (a call missing required constructor
+  arguments). The **directory mode is now fixed for real**, reading that same
+  ``rssfeed`` file from disk instead of from inside a zip -- useful for local
+  debugging, where it's convenient to edit filings directly rather than
+  repackaging them into a zip after every change. The **bare single-file mode is
+  removed**: a lone filing has no room for an accompanying ``rssfeed`` file, so
+  there's no way to determine its publication time or taxonomy version. Both
+  input types now raise a clear ``ValueError`` on invalid input instead of
+  crashing.
 
 .. _release-v1-10-0:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ relative_files = true
 precision = 2
 sort = "miss"
 skip_empty = true
-fail_under = 96
+fail_under = 99
 # fail_under is enforced once, after unit and integration coverage are combined, by
 # the final "coverage report" invocation in the `all` hatch script under
 # [tool.hatch.envs.test.scripts] above -- not here, since pytest-cov would otherwise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ relative_files = true
 precision = 2
 sort = "miss"
 skip_empty = true
-fail_under = 95
+fail_under = 96
 # fail_under is enforced once, after unit and integration coverage are combined, by
 # the final "coverage report" invocation in the `all` hatch script under
 # [tool.hatch.envs.test.scripts] above -- not here, since pytest-cov would otherwise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,14 @@ types = [
     "ty>=0.0.61", # Extremely fast Rust-based Python type checker, from Astral
 ]
 
+[tool.uv]
+# Always use a uv-managed Python distribution -- never one discovered on the system
+# (Homebrew, apt, pyenv, etc.) -- and fetch it automatically if the pinned version
+# (see .python-version) isn't installed yet. Keeps local dev and CI reproducible
+# without relying on actions/setup-python or whatever happens to be on PATH.
+python-preference = "only-managed"
+python-downloads = "automatic"
+
 [tool.hatch.version]
 source = "vcs"
 
@@ -109,6 +117,13 @@ packages = ["src/ferc_xbrl_extractor"]
 [tool.hatch.envs.default]
 description = "Default environment with all development dependencies"
 features = ["dev", "docs", "tests", "types"]
+# Delegate venv creation and package installation to uv rather than pip/virtualenv.
+# Hatch still resolves *which* interpreter to hand uv (see the `python` pin below),
+# but once resolved, this makes uv do the actual venv creation and installs, and lets
+# HATCH_PYTHON (set to a `uv python find` path in CI) bypass Hatch's own PATH
+# discovery entirely -- see AGENTS.md and .github/workflows/*.yml.
+installer = "uv"
+python = "3.14"
 
 [tool.hatch.envs.test]
 description = "Run tests with pytest and collect test coverage"
@@ -135,6 +150,10 @@ all = ["coverage-erase", "unit", "integration", "coverage-report"]
 description = "Run linters and formatters"
 features = ["tests"]
 detached = true
+# `detached` makes this its own template root, so it doesn't inherit `installer`/
+# `python` from [tool.hatch.envs.default] -- repeat them here.
+installer = "uv"
+python = "3.14"
 
 [tool.hatch.envs.lint.scripts]
 check = ["ruff check ./", "ruff format --check ./"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ unit = "pytest --cov=src/ferc_xbrl_extractor --cov=tests --cov-append --cov-fail
 # tests parallelized this way each cap their own internal extraction concurrency
 # (workers=1) rather than also spawning a per-test process pool -- see comments in
 # tests/integration/data_quality_test.py and console_scripts_test.py.
-integration = "pytest -n auto --cov=src/ferc_xbrl_extractor --cov=tests --cov-append --cov-fail-under=0 --no-cov-on-fail tests/integration {args}"
+integration = "pytest -n auto --durations 10 --cov=src/ferc_xbrl_extractor --cov=tests --cov-append --cov-fail-under=0 --no-cov-on-fail tests/integration {args}"
 coverage-report = ["coverage report", "coverage xml"]
 all = ["coverage-erase", "unit", "integration", "coverage-report"]
 

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -13,7 +13,35 @@ from pydantic import BaseModel
 
 
 def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: int = 7):
-    """Actually use Arelle to get a taxonomy and its relationships."""
+    """Use Arelle to load a taxonomy and build its parent-child relationship view.
+
+    As it parses a taxonomy, Arelle downloads the schema/linkbase files it
+    references to a local on-disk cache (managed by Arelle's own ``webCache``),
+    then reads them back from there. When two or more callers load the *same*
+    taxonomy concurrently -- e.g. multiple threads or processes each extracting
+    a different filing that shares one taxonomy version -- their cache writes
+    can race, and Arelle raises ``FileExistsError`` when one caller tries to
+    create a cache file another is already writing.
+
+    This is a transient condition, not a real failure: by the time we retry,
+    the other caller has usually finished writing the file, so the retried
+    ``ModelXbrl.load`` call reads the now-complete cache entry instead of
+    trying to write it again. The loop therefore retries *only*
+    ``FileExistsError``, with exponential backoff, up to ``max_retries``
+    attempts before giving up and re-raising. Any other exception (a genuinely
+    missing taxonomy, malformed XBRL, an unrelated network error, ...) is
+    allowed to propagate immediately on the first attempt, since retrying
+    those wouldn't help -- they aren't the race this loop exists to work
+    around. See ``test_concurrent_taxonomy_load`` (integration) and
+    ``test_taxonomy_view_retries_then_raises_after_max_retries`` (unit) for
+    coverage of this behavior.
+
+    Args:
+        taxonomy_source: URL, local path, or in-memory ``FileSource`` pointing
+            at the taxonomy entry point.
+        max_retries: Maximum number of load attempts before giving up and
+            re-raising the last ``FileExistsError``.
+    """
     cntlr = Cntlr.Cntlr()
     cntlr.startLogging(logFileName="logToPrint")
     model_manager = ModelManager.initialize(cntlr)

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -21,7 +21,7 @@ def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: in
         try:
             cntlr.logger.debug(f"Try #{try_count}: {taxonomy_source=}")
             taxonomy = ModelXbrl.load(model_manager, taxonomy_source)
-            continue
+            break
         except FileExistsError as e:
             if (try_count + 1) == max_retries:
                 raise e

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -1,9 +1,8 @@
 """Abstract away interface to Arelle XBRL Library."""
 
-import io
 import time
 from pathlib import Path
-from typing import Literal
+from typing import BinaryIO, Literal
 
 import pydantic
 import stringcase
@@ -36,7 +35,7 @@ def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: in
     return taxonomy, view
 
 
-def load_taxonomy(path: Path):
+def load_taxonomy(path: str | Path):
     """Load XBRL taxonomy, and parse relationships.
 
     Args:
@@ -47,7 +46,7 @@ def load_taxonomy(path: Path):
     return _taxonomy_view(source)
 
 
-def load_taxonomy_from_archive(taxonomy_archive: io.BytesIO, entry_point: Path):
+def load_taxonomy_from_archive(taxonomy_archive: BinaryIO, entry_point: str | Path):
     """Load an XBRL taxonomy from a zipfile archive.
 
     Args:
@@ -71,7 +70,7 @@ class References(BaseModel):
     used by FERC.
     """
 
-    account: str = pydantic.Field(None, alias="Account")
+    account: str | None = pydantic.Field(None, alias="Account")
     form_location: list[dict[str, str]] = pydantic.Field([], alias="Form Location")
 
 

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -27,7 +27,10 @@ def parse():
     parser.add_argument(
         "filings",
         nargs="+",
-        help="Path to a single XBRL filing, a directory of XBRL filings, or a zipfile containing XBRL filings.",
+        help=(
+            "Path to a zipfile containing XBRL filings, or a directory of "
+            "already-unzipped filings including the 'rssfeed' metadata file."
+        ),
         type=Path,
     )
     parser.add_argument(

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -101,7 +101,7 @@ def write_to_sqlite(sqlite_engine: Engine, table_name: str, table_data: pd.DataF
         table_data.to_sql(table_name, sqlite_conn, if_exists="replace")
 
 
-def write_to_duckdb(duckdb_path: str, table_name: str, table_data: pd.DataFrame):
+def write_to_duckdb(duckdb_path: str | Path, table_name: str, table_data: pd.DataFrame):
     """Write one table to a duckdb database."""
     table_data = table_data.reset_index()
     with duckdb.connect(duckdb_path) as duckdb_conn:
@@ -113,7 +113,7 @@ def write_to_duckdb(duckdb_path: str, table_name: str, table_data: pd.DataFrame)
 def load_extracted(
     extracted: xbrl.ExtractOutput,
     sqlite_uri: str,
-    duckdb_path: str | None,
+    duckdb_path: str | Path | None,
 ) -> None:
     """Write extracted data to SQLite/Duckdb databases."""
     engine = create_engine(sqlite_uri)
@@ -132,7 +132,7 @@ def run_main(
     taxonomy: str | Path | io.BytesIO,
     output_dir: Path,
     sqlite_path: Path,
-    duckdb_path: Path,
+    duckdb_path: Path | None,
     form_number: int,
     workers: int | None,
     batch_size: int | None,
@@ -148,6 +148,10 @@ def run_main(
     coloredlogs.install(fmt=log_format, level=loglevel, logger=logger)
 
     sqlite_uri = f"sqlite:///{sqlite_path.absolute()}"
+    # Default to writing DuckDB output alongside the SQLite output, unless the user
+    # asked for some other duckdb path.
+    if duckdb_path is None:
+        duckdb_path = sqlite_path.with_suffix(".duckdb")
     datapackage_path = output_dir / f"ferc{form_number}_xbrl_datapackage.json"
     metadata_path = output_dir / f"ferc{form_number}_xbrl_taxonomy_metadata.json"
 
@@ -174,7 +178,7 @@ def run_main(
         filings=filings,
         workers=workers,
         batch_size=batch_size,
-        requested_tables=requested_tables,
+        requested_tables=set(requested_tables) if requested_tables else None,
         instance_pattern=instance_pattern,
     )
     # Save extracted data in SQLite/duckdb

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -443,10 +443,17 @@ class FactTable:
 
         facts["publication_time"] = instance.publication_time
 
-        contexts = facts.index.to_series().apply(
-            lambda c_id: pd.Series(
+        # Building this via DataFrame.from_records() instead of
+        # `facts.index.to_series().apply(lambda c_id: pd.Series(...))` avoids
+        # constructing one pd.Series per row -- profiling showed that per-row
+        # apply() accounting for ~20% of total extraction time, since it runs
+        # once per context per fact table per filing.
+        contexts = pd.DataFrame.from_records(
+            [
                 instance.contexts[c_id].as_primary_key(instance.filing_name, self.axes)
-            )
+                for c_id in facts.index
+            ],
+            index=facts.index,
         )
 
         return (

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -420,7 +420,7 @@ class FactTable:
         instance.used_fact_ids |= {f.f_id() for f in raw_facts}
 
         if not raw_facts:
-            return pd.DataFrame(columns=self.columns.keys()).set_index(
+            return pd.DataFrame(columns=list(self.columns.keys())).set_index(
                 self.schema.primary_key
             )
 

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -429,18 +429,15 @@ class InstanceBuilder:
         )
 
 
-def instances_from_zip(instance_path: Path | io.BytesIO) -> list[InstanceBuilder]:
-    """Get list of instances from specified path to zipfile.
+def _parse_rssfeed_metadata(
+    raw: bytes,
+) -> tuple[dict[str, datetime.datetime], dict[str, str]]:
+    """Parse an "rssfeed" metadata file into publication times and taxonomy versions.
 
-    Args:
-        instance_path: Path to zipfile containing XBRL filings.
+    Shared by instances_from_zip and instances_from_directory, which differ only
+    in where they read the "rssfeed" file and individual filings from.
     """
-    allowable_suffixes = [".xbrl"]
-
-    archive = zipfile.ZipFile(instance_path)
-
-    with archive.open("rssfeed") as f:
-        filings_metadata = json.loads(f.read())
+    filings_metadata = json.loads(raw)
 
     # Publication time is always published as UTC, but just to be safe convert to UTC
     # then make timezone naive
@@ -458,6 +455,21 @@ def instances_from_zip(instance_path: Path | io.BytesIO) -> list[InstanceBuilder
         for filers_metadata in filings_metadata.values()
         for filing in filers_metadata
     }
+    return publication_times, taxonomy_versions
+
+
+def instances_from_zip(instance_path: Path | io.BytesIO) -> list[InstanceBuilder]:
+    """Get list of instances from specified path to zipfile.
+
+    Args:
+        instance_path: Path to zipfile containing XBRL filings.
+    """
+    allowable_suffixes = [".xbrl"]
+
+    archive = zipfile.ZipFile(instance_path)
+
+    with archive.open("rssfeed") as f:
+        publication_times, taxonomy_versions = _parse_rssfeed_metadata(f.read())
 
     # Read files into in memory buffers to parse
     return [
@@ -472,14 +484,62 @@ def instances_from_zip(instance_path: Path | io.BytesIO) -> list[InstanceBuilder
     ]
 
 
-def get_instances(instance_path: Path | io.BytesIO) -> list[InstanceBuilder]:
-    """Get list of instances from specified path.
+def instances_from_directory(instance_path: Path) -> list[InstanceBuilder]:
+    """Get list of instances from a directory of unzipped XBRL filings.
+
+    Mainly useful for local debugging, where it's convenient to edit filings
+    directly on disk rather than repackaging them into a zip after every change.
+    The directory must still include the "rssfeed" metadata file that FERC's
+    archiving process bundles into the zip alongside the filings -- e.g. by
+    unzipping one of these archives without discarding it -- since that's the
+    only source for each filing's publication_time and taxonomy_version. See
+    instances_from_zip for the zip-archive equivalent of this function.
 
     Args:
-        instance_path: Path to one or more XBRL filings.
+        instance_path: Path to a directory of XBRL filings, including an
+            "rssfeed" metadata file.
     """
     allowable_suffixes = [".xbrl"]
 
+    rssfeed_path = instance_path / "rssfeed"
+    if not rssfeed_path.exists():
+        raise ValueError(
+            f"Could not find an 'rssfeed' metadata file in {instance_path}. "
+            "get_instances() expects a directory of XBRL filings to include "
+            "the 'rssfeed' file bundled by FERC's archiving process -- see "
+            "its docstring."
+        )
+    publication_times, taxonomy_versions = _parse_rssfeed_metadata(
+        rssfeed_path.read_bytes()
+    )
+
+    return [
+        InstanceBuilder(
+            str(instance),
+            instance.stem,
+            publication_time=publication_times[instance.name],
+            taxonomy_version=taxonomy_versions[instance.name],
+        )
+        for instance in sorted(instance_path.iterdir())
+        if instance.suffix in allowable_suffixes
+    ]
+
+
+def get_instances(instance_path: Path | io.BytesIO) -> list[InstanceBuilder]:
+    """Get list of instances from a zipfile or directory of XBRL filings.
+
+    Both a zip archive (or in-memory equivalent) and a plain directory are
+    supported, as long as an "rssfeed" metadata file is present -- FERC's
+    archiving process bundles one into every zip archive automatically, and
+    it's still there if you unzip one without discarding it. Each filing's
+    publication_time and taxonomy_version are derived from that file; without
+    it there's no reliable way to determine them, which is why a bare single
+    filing (with no "rssfeed" of its own) isn't supported.
+
+    Args:
+        instance_path: Path to a zipfile or directory of XBRL filings, or an
+            in-memory zip archive.
+    """
     if isinstance(instance_path, io.BytesIO):
         return instances_from_zip(instance_path)
 
@@ -489,17 +549,10 @@ def get_instances(instance_path: Path | io.BytesIO) -> list[InstanceBuilder]:
     if instance_path.suffix == ".zip":
         return instances_from_zip(instance_path)
 
-    # Single instance
-    if instance_path.is_file():
-        instances = [instance_path]
-    # Directory of instances
-    else:
-        # Must be either a directory or file
-        assert instance_path.is_dir()  # nosec: B101
-        instances = sorted(instance_path.iterdir())
+    if instance_path.is_dir():
+        return instances_from_directory(instance_path)
 
-    return [
-        InstanceBuilder(str(instance), instance.name.rstrip(instance.suffix))
-        for instance in sorted(instances)
-        if instance.suffix in allowable_suffixes
-    ]
+    raise ValueError(
+        f"Expected a zipfile or directory of XBRL filings, got {instance_path}. "
+        "get_instances() only supports those two input types -- see its docstring."
+    )

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -6,6 +6,7 @@ import itertools
 import json
 import zipfile
 from collections import Counter, defaultdict
+from collections.abc import Iterator
 from enum import Enum, auto
 from functools import cached_property
 from pathlib import Path
@@ -41,10 +42,14 @@ class Period(BaseModel):
         if instant is not None:
             return cls(instant=True, end_date=instant.text)
 
+        start_date_elem = elem.find(f"{{{XBRL_INSTANCE}}}startDate")
+        end_date_elem = elem.find(f"{{{XBRL_INSTANCE}}}endDate")
+        assert start_date_elem is not None
+        assert end_date_elem is not None
         return cls(
             instant=False,
-            start_date=elem.find(f"{{{XBRL_INSTANCE}}}startDate").text,
-            end_date=elem.find(f"{{{XBRL_INSTANCE}}}endDate").text,
+            start_date=start_date_elem.text,
+            end_date=end_date_elem.text,
         )
 
 
@@ -89,7 +94,7 @@ class Axis(BaseModel):
             )
 
         if elem.tag.endswith("typedMember"):
-            dim = elem.getchildren()[0]
+            dim = elem[0]
             return cls(
                 name=elem.attrib["dimension"],
                 value=dim.text if dim.text else "",
@@ -118,8 +123,11 @@ class Entity(BaseModel):
         segment = elem.find(f"{{{XBRL_INSTANCE}}}segment")
         dims = segment.findall("*") if segment is not None else []
 
+        identifier_elem = elem.find(f"{{{XBRL_INSTANCE}}}identifier")
+        assert identifier_elem is not None
+
         return cls(
-            identifier=elem.find(f"{{{XBRL_INSTANCE}}}identifier").text,
+            identifier=identifier_elem.text,
             dimensions=[Axis.from_xml(child) for child in dims],
         )
 
@@ -148,12 +156,14 @@ class Context(BaseModel):
     @classmethod
     def from_xml(cls, elem: Element) -> "Context":
         """Construct Context from XML element."""
+        entity_elem = elem.find(f"{{{XBRL_INSTANCE}}}entity")
+        period_elem = elem.find(f"{{{XBRL_INSTANCE}}}period")
+        assert entity_elem is not None
+        assert period_elem is not None
         return cls(
-            **{
-                "c_id": elem.attrib["id"],
-                "entity": Entity.from_xml(elem.find(f"{{{XBRL_INSTANCE}}}entity")),
-                "period": Period.from_xml(elem.find(f"{{{XBRL_INSTANCE}}}period")),
-            }
+            c_id=elem.attrib["id"],
+            entity=Entity.from_xml(entity_elem),
+            period=Period.from_xml(period_elem),
         )
 
     def check_dimensions(self, primary_key: list[str]) -> bool:
@@ -181,8 +191,9 @@ class Context(BaseModel):
         if self.period.instant:
             date_dict = {"date": self.period.end_date}
         else:
+            # start_date is always populated for duration periods -- see Period.from_xml.
+            assert self.period.start_date is not None
             date_dict = {
-                # Ignore type because start_date will always be str if duration period
                 "start_date": self.period.start_date,
                 "end_date": self.period.end_date,
             }
@@ -292,21 +303,25 @@ class Instance:
         self.filing_name = filing_name
         self.contexts = contexts
         if "report_date" in duration_facts:
-            self.report_date = datetime.date.fromisoformat(
-                duration_facts["report_date"][0].value
-            )
+            report_date_value = duration_facts["report_date"][0].value
+            assert report_date_value is not None
+            self.report_date = datetime.date.fromisoformat(report_date_value)
         else:
             # FERC 714 workaround - though sometimes reports with different
             # publish dates have the same certifying official date.
+            certifying_official_date_value = duration_facts["certifying_official_date"][
+                0
+            ].value
+            assert certifying_official_date_value is not None
             self.report_date = datetime.date.fromisoformat(
-                duration_facts["certifying_official_date"][0].value
+                certifying_official_date_value
             )
         self.publication_time = publication_time
 
     def get_facts(
         self, instant: bool, concept_names: list[str], primary_key: list[str]
-    ) -> dict[str, list[Fact]]:
-        """Return a dictionary that maps Context ID's to a list of facts for each context.
+    ) -> Iterator[Fact]:
+        """Return facts for the requested concepts whose context matches primary_key.
 
         Args:
             instant: Get facts with instant or duration period.
@@ -379,8 +394,14 @@ class InstanceBuilder:
         # Find all contexts in XML file
         contexts = root.findall(f"{{{XBRL_INSTANCE}}}context")
 
-        # Find all facts in XML file
-        facts = root.findall(f"{fact_prefix}:*", root.nsmap)
+        # Find all facts in XML file. Filter out the default-namespace entry (key
+        # None) since it's not needed to match the always-prefixed fact_prefix:*
+        # expression below, and lxml-stubs types the namespaces mapping as str-keys
+        # only even though lxml itself accepts a None key at runtime.
+        nsmap = {
+            prefix: uri for prefix, uri in root.nsmap.items() if prefix is not None
+        }
+        facts = root.findall(f"{fact_prefix}:*", nsmap)
 
         # Loop through contexts and parse into pydantic structures
         for context in contexts:

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -39,22 +39,6 @@ class XBRLType(BaseModel):
         """Construct XBRLType class from arelle ModelType."""
         return cls(name=arelle_type.name, base=arelle_type.baseXsdType.lower())
 
-    def get_pandas_type(self) -> str | None:
-        """Return corresponding pandas type.
-
-        Gets a string representation of the pandas type best suited to represent the
-        base type.
-        """
-        if self.base == "string" or self.base == "date" or self.base == "duration":
-            return "string"
-        if self.base == "decimal":
-            return "Float64"
-        if self.base == "gyear" or self.base == "integer":
-            return "Int64"
-        if self.base == "boolean":
-            return "boolean"
-        return None
-
     def get_schema_type(self) -> str:
         """Return string specifying type for a frictionless table schema."""
         if self.base == "gyear":

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -2,7 +2,7 @@
 
 import io
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, BinaryIO, Literal
 
 import pydantic
 from arelle import XbrlConst
@@ -145,6 +145,7 @@ class Concept(BaseModel):
         # If concept is leaf node return metadata
         else:
             if period_type == self.period_type:
+                assert self.metadata is not None
                 metadata[self.name] = self.metadata.model_dump()
 
         return metadata
@@ -230,8 +231,8 @@ class Taxonomy(BaseModel):
     @classmethod
     def from_source(
         cls,
-        taxonomy_source: Path | io.BytesIO,
-        entry_point: Path | None = None,
+        taxonomy_source: Path | BinaryIO,
+        entry_point: str | Path,
     ):
         """Construct taxonomy from taxonomy URL.
 
@@ -242,8 +243,7 @@ class Taxonomy(BaseModel):
 
         Args:
             taxonomy_source: Path to taxonomy or in memory archive of taxonomy.
-            entry_point: Path to taxonomy entry point within archive. If not None,
-                then `taxonomy` should be a path to zipfile, not a URL.
+            entry_point: Path to taxonomy entry point within archive.
         """
         if isinstance(taxonomy_source, Path):
             taxonomy_source = io.BytesIO(taxonomy_source.read_bytes())

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -48,7 +48,9 @@ def extract(
     """Extract fact tables from instance documents as Pandas dataframes.
 
     Args:
-        filings: list of filings or zip files with filings.
+        filings: list of zip files (or in-memory equivalents) containing filings,
+            or directories of already-unzipped filings including the "rssfeed"
+            metadata file -- see get_instances.
         taxonomy_source: either a URL/path to taxonomy or in memory archive of
             taxonomy.
         form_number: the FERC form number (1, 2, 6, 60, 714).

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor as Executor
 from functools import partial
 from pathlib import Path
+from typing import BinaryIO, TypedDict, cast
 from zipfile import ZipFile
 
 import numpy as np
@@ -25,9 +26,16 @@ from ferc_xbrl_extractor.taxonomy import Taxonomy, get_metadata_from_taxonomies
 ExtractOutput = namedtuple("ExtractOutput", ["table_defs", "table_data", "stats"])
 
 
+class BatchResult(TypedDict):
+    """Dataframes and metadata extracted from one batch of instances."""
+
+    dfs: dict[str, pd.DataFrame]
+    metadata: dict[str, dict]
+
+
 def extract(
     filings: list[Path] | list[io.BytesIO],
-    taxonomy_source: Path | io.BytesIO,
+    taxonomy_source: str | Path | io.BytesIO,
     form_number: int,
     db_uri: str,
     datapackage_path: Path | None = None,
@@ -139,7 +147,7 @@ def table_data_from_instances(
 def process_batch(
     instance_builders: Iterable[InstanceBuilder],
     table_defs: dict[str, FactTable],
-) -> tuple[dict[str, pd.DataFrame], set[str]]:
+) -> BatchResult:
     """Extract data from one batch of instances.
 
     Splitting instances into batches significantly improves multiprocessing
@@ -176,9 +184,9 @@ def process_batch(
             category=FutureWarning,
             message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.",
         )
-        dfs = {key: pd.concat(df_list) for key, df_list in dfs.items()}
+        concatenated_dfs = {key: pd.concat(df_list) for key, df_list in dfs.items()}
 
-    return {"dfs": dfs, "metadata": metadata}
+    return {"dfs": concatenated_dfs, "metadata": metadata}
 
 
 def process_instance(
@@ -207,12 +215,12 @@ def process_instance(
 
 
 def get_fact_tables(
-    taxonomy_source: Path | io.BytesIO,
+    taxonomy_source: str | Path | io.BytesIO,
     form_number: int,
     db_uri: str,
     filter_tables: set[str] | None = None,
-    datapackage_path: str | None = None,
-    metadata_path: str | None = None,
+    datapackage_path: str | Path | None = None,
+    metadata_path: str | Path | None = None,
 ) -> dict[str, FactTable]:
     """Parse taxonomy from URL.
 
@@ -251,7 +259,12 @@ def get_fact_tables(
                 )
 
                 taxonomy_entry_point = f"taxonomy/form{form_number}/{taxonomy_date}/form/form{form_number}/form-{form_number}_{taxonomy_date}.xsd"
-                taxonomy = Taxonomy.from_source(f, entry_point=taxonomy_entry_point)
+                # ZipFile.open() is typed IO[bytes] in typeshed, but the ZipExtFile
+                # it actually returns satisfies BinaryIO at runtime -- the stub is
+                # just imprecise here.
+                taxonomy = Taxonomy.from_source(
+                    cast(BinaryIO, f), entry_point=taxonomy_entry_point
+                )
                 taxonomies[taxonomy_version] = taxonomy
 
     datapackage = Datapackage.from_taxonomies(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,33 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_collection_modifyitems(items):
+    """Schedule the slowest tests first so xdist runs them in parallel, not at the tail.
+
+    pytest-xdist's default "load" scheduler hands tests to workers in collection
+    order, dispatching the next not-yet-run item to whichever worker frees up
+    first. If a slow test sits late in that order, it gets dispatched late and
+    ends up running alone after every other worker has drained its queue,
+    stretching overall wall-clock time. Sorting known-slow tests to the front
+    gets them dispatched -- and running alongside everything else -- from the
+    start of the run instead. Ordered longest-running first; more specific
+    substrings must precede the shorter ones they contain.
+    """
+    slow_first = (
+        "test_concurrent_taxonomy_load",
+        "test_extract_example_filings_default_duckdb_path",
+        "test_extract_example_filings",
+    )
+
+    def priority(item: pytest.Item) -> int:
+        for rank, name in enumerate(slow_first):
+            if name in item.nodeid:
+                return rank
+        return len(slow_first)
+
+    items.sort(key=priority)
+
+
 @pytest.fixture(scope="session")
 def data_dir(request) -> Path:
     return request.config.getoption("--integration-data-dir")

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -123,6 +123,41 @@ def test_extract_example_filings(script_runner, tmp_path, test_dir):
 
 
 @pytest.mark.script_launch_mode("inprocess")
+def test_extract_example_filings_default_duckdb_path(script_runner, tmp_path, test_dir):
+    """Test that omitting --duckdb-path still produces a DuckDB output.
+
+    Regression test: run_main() used to unconditionally call
+    convert_duckdb_into_parquet() with duckdb_path=None whenever --duckdb-path was
+    omitted, which crashed with duckdb.InvalidInputException. It now defaults to
+    the sqlite path with a .duckdb suffix instead.
+    """
+    form_number = 1
+    output_dir = tmp_path
+    sqlite_path = tmp_path / f"ferc{form_number}-2021-sample.sqlite"
+    data_dir = test_dir / "integration" / "data"
+
+    ret = script_runner.run(
+        [
+            "xbrl_extract",
+            str(data_dir / f"ferc{form_number}-xbrl-2021.zip"),
+            "--output-dir",
+            str(output_dir),
+            "--sqlite-path",
+            str(sqlite_path),
+            "--taxonomy",
+            str(data_dir / f"ferc{form_number}-xbrl-taxonomies.zip"),
+            "--form-number",
+            1,
+            "--workers",
+            1,
+        ]
+    )
+
+    assert ret.success
+    assert (tmp_path / f"ferc{form_number}-2021-sample.duckdb").exists()
+
+
+@pytest.mark.script_launch_mode("inprocess")
 def test_extract_example_filings_bad_form(script_runner, tmp_path, test_dir):
     """Test the XBRL extraction on the example filings.
 

--- a/tests/integration/datapackage_test.py
+++ b/tests/integration/datapackage_test.py
@@ -63,6 +63,29 @@ def test_datapackage_generation(test_dir, data_dir):
     assert Package.validate_descriptor(datapackage.model_dump(by_alias=True))
 
 
+def test_taxonomy_from_source_accepts_path(tmp_path, data_dir):
+    """Taxonomy.from_source() also accepts a bare Path, not just an open file.
+
+    Every other caller in this repo already has an open file object in hand
+    (from a zip archive being processed elsewhere) and uses that, so this
+    branch -- reading the whole archive into memory itself -- isn't otherwise
+    exercised. ferc1-xbrl-taxonomies.zip is a zip-of-zips (one per taxonomy
+    version), so extract the specific per-version zip to a real file on disk
+    first, since that's the granularity from_source() actually expects.
+    """
+    version = "form-1-2022-01-01.zip"
+    with zipfile.ZipFile(data_dir / "ferc1-xbrl-taxonomies.zip") as archive:
+        taxonomy_zip_path = tmp_path / version
+        taxonomy_zip_path.write_bytes(archive.read(version))
+
+    taxonomy = Taxonomy.from_source(
+        taxonomy_zip_path,
+        entry_point=Path("taxonomy/form1/2022-01-01/form/form1/form-1_2022-01-01.xsd"),
+    )
+
+    assert len(taxonomy.roles) > 0
+
+
 def _create_schema(instant=True, axes=None):
     if not axes:
         axes = []

--- a/tests/integration/datapackage_test.py
+++ b/tests/integration/datapackage_test.py
@@ -4,6 +4,7 @@ import datetime
 import io
 import zipfile
 from pathlib import Path
+from typing import BinaryIO, cast
 
 import pandas as pd
 import pytest
@@ -39,7 +40,9 @@ def test_datapackage_generation(test_dir, data_dir):
             archive.open(version, mode="r") as f,
         ):
             taxonomies[version] = Taxonomy.from_source(
-                f,
+                # ZipFile.open() is typed IO[bytes] in typeshed, but the ZipExtFile
+                # it actually returns satisfies BinaryIO at runtime.
+                cast(BinaryIO, f),
                 entry_point=Path(entry_point),
             )
     datapackage = Datapackage.from_taxonomies(taxonomies, "sqlite:///test_db.sqlite")

--- a/tests/integration/xbrl_test.py
+++ b/tests/integration/xbrl_test.py
@@ -1,0 +1,27 @@
+"""Integration tests for ferc_xbrl_extractor.xbrl."""
+
+import pytest
+
+from ferc_xbrl_extractor.xbrl import get_fact_tables
+
+
+def test_get_fact_tables_rejects_invalid_datapackage(data_dir, tmp_path, mocker):
+    """get_fact_tables() raises a clear error if the generated datapackage is invalid.
+
+    Forces the failure by mocking frictionless's validator, since we don't have a
+    real taxonomy on hand that happens to produce an invalid datapackage -- this
+    is purely testing that the check-and-raise wiring works.
+    """
+    mock_report = mocker.Mock(valid=False, errors=["some validation error"])
+    mocker.patch(
+        "ferc_xbrl_extractor.xbrl.Package.validate_descriptor",
+        return_value=mock_report,
+    )
+
+    with pytest.raises(RuntimeError, match="Generated datapackage is invalid"):
+        get_fact_tables(
+            taxonomy_source=data_dir / "ferc1-xbrl-taxonomies.zip",
+            form_number=1,
+            db_uri="sqlite:///test.sqlite",
+            datapackage_path=tmp_path / "datapackage.json",
+        )

--- a/tests/unit/arelle_interface_test.py
+++ b/tests/unit/arelle_interface_test.py
@@ -1,0 +1,32 @@
+"""Test the internal Arelle interface helpers."""
+
+import pytest
+
+import ferc_xbrl_extractor.arelle_interface as arelle_interface
+
+
+def test_taxonomy_view_retries_then_raises_after_max_retries(mocker):
+    """_taxonomy_view() retries with exponential backoff, then re-raises.
+
+    Regression coverage for the retry loop, which handles Arelle's shared
+    taxonomy cache raising FileExistsError under concurrent access. See
+    test_concurrent_taxonomy_load in tests/integration/arelle_interface_test.py
+    for a real (but not reliably triggered) end-to-end exercise of this same
+    path -- this test forces the failure deterministically instead.
+    """
+    mocker.patch.object(
+        arelle_interface.Cntlr, "Cntlr", return_value=mocker.MagicMock()
+    )
+    mocker.patch.object(
+        arelle_interface.ModelManager, "initialize", return_value=mocker.MagicMock()
+    )
+    mock_sleep = mocker.patch.object(arelle_interface.time, "sleep")
+    mock_load = mocker.patch.object(
+        arelle_interface.ModelXbrl, "load", side_effect=FileExistsError
+    )
+
+    with pytest.raises(FileExistsError):
+        arelle_interface._taxonomy_view("fake_source", max_retries=3)
+
+    assert mock_load.call_count == 3
+    mock_sleep.assert_has_calls([mocker.call(2), mocker.call(4)])

--- a/tests/unit/cli_test.py
+++ b/tests/unit/cli_test.py
@@ -1,0 +1,38 @@
+"""Test the FERC XBRL extractor CLI helpers."""
+
+import json
+
+import pytest
+
+from ferc_xbrl_extractor.cli import convert_and_validate_datapackage_sqlite_to_parquet
+
+
+def test_convert_and_validate_datapackage_sqlite_to_parquet_rejects_invalid(
+    tmp_path, mocker
+):
+    """Raises a clear error if the rewritten datapackage fails validation.
+
+    Forces the failure by mocking frictionless's validator, since constructing a
+    real datapackage descriptor that's invalid in just the right way isn't worth
+    the trouble -- this is purely testing that the check-and-raise wiring works.
+    """
+    datapackage = {
+        "resources": [
+            {
+                "name": "test_table",
+                "path": "test_table",
+                "dialect": {"table": "test_table"},
+            }
+        ]
+    }
+    datapackage_path = tmp_path / "datapackage.json"
+    datapackage_path.write_text(json.dumps(datapackage))
+
+    mock_report = mocker.Mock(valid=False, errors=["some validation error"])
+    mocker.patch(
+        "ferc_xbrl_extractor.cli.Package.validate_descriptor",
+        return_value=mock_report,
+    )
+
+    with pytest.raises(RuntimeError, match="Generated datapackage is invalid"):
+        convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path)

--- a/tests/unit/datapackage_test.py
+++ b/tests/unit/datapackage_test.py
@@ -1,14 +1,35 @@
 """Test XBRL extraction interface."""
 
+import datetime
 import logging
 
 import pandas as pd
 import pytest
 
-from ferc_xbrl_extractor.datapackage import Resource, clean_table_names, fuzzy_dedup
+from ferc_xbrl_extractor.datapackage import (
+    Dialect,
+    FactTable,
+    Field,
+    Resource,
+    Schema,
+    clean_table_names,
+    fuzzy_dedup,
+)
+from ferc_xbrl_extractor.instance import Fact, Instance
 from ferc_xbrl_extractor.taxonomy import LinkRole
 
 logger = logging.getLogger(__name__)
+
+
+def _make_resource(schema: Schema) -> Resource:
+    return Resource(
+        path="db",
+        name="table",
+        dialect=Dialect(table="table"),
+        title="Table",
+        description="A table",
+        schema=schema,
+    )
 
 
 @pytest.mark.parametrize(
@@ -213,3 +234,59 @@ def test_clean_table_names(input_name: str, cleaned_name: str | None, is_bad: bo
             clean_table_names(input_name)
     else:
         assert clean_table_names(input_name) == cleaned_name
+
+
+def test_merge_resources_rejects_incompatible_primary_keys():
+    """Resource.merge_resources() rejects tables with mismatched primary keys.
+
+    This can happen if a table's structure changed enough between taxonomy
+    versions that its primary key itself differs, which isn't something we can
+    meaningfully merge.
+    """
+    schema_a = Schema(
+        primary_key=["date"],
+        fields=[Field(name="date", title="Date", description="date")],
+    )
+    schema_b = Schema(
+        primary_key=["date", "extra_axis"],
+        fields=[
+            Field(name="date", title="Date", description="date"),
+            Field(name="extra_axis", title="Extra Axis", description="extra"),
+        ],
+    )
+    resource_a = _make_resource(schema_a)
+    resource_b = _make_resource(schema_b)
+
+    with pytest.raises(RuntimeError, match="incompatible schemas"):
+        resource_a.merge_resources(resource_b, other_version="form-1-2023-01-01.zip")
+
+
+def test_construct_dataframe_with_no_matching_facts():
+    """FactTable.construct_dataframe() handles an instance with no matching facts.
+
+    Returns an empty, but correctly shaped (indexed on the primary key) dataframe,
+    rather than erroring.
+    """
+    schema = Schema(
+        primary_key=["date"],
+        fields=[Field(name="date", title="Date", description="date")],
+    )
+    fact_table = FactTable(schema=schema, period_type="instant")
+
+    instance = Instance(
+        contexts={},
+        instant_facts={},
+        duration_facts={
+            "report_date": [
+                Fact(name="report_date", c_id="context_1", value="2022-08-12")
+            ]
+        },
+        filing_name="test_instance",
+        taxonomy_version="form-1-2022-01-01.zip",
+        publication_time=datetime.datetime(2023, 10, 20, 0, 1, 2),
+    )
+
+    df = fact_table.construct_dataframe(instance)
+
+    assert df.empty
+    assert df.index.names == ["date"]

--- a/tests/unit/instance_test.py
+++ b/tests/unit/instance_test.py
@@ -1,13 +1,17 @@
 """Test XBRL instance interface."""
 
 import datetime
+import io
 import json
 import logging
+import zipfile
 from collections import Counter
 
 import pytest
+from lxml import etree  # nosec: B410
 
 from ferc_xbrl_extractor.instance import (
+    Axis,
     Context,
     DimensionType,
     Entity,
@@ -90,6 +94,34 @@ def test_context_ids(test_context):
 
     assert context_ids.get("start_date") == test_context.period.start_date
     assert context_ids.get("end_date") == test_context.period.end_date
+
+
+def test_context_hash(test_context):
+    """Context.__hash__ is based only on c_id, not the rest of its fields."""
+    same_id_different_entity = Context(
+        c_id=test_context.c_id,
+        entity=Entity(identifier="a_totally_different_entity", dimensions=[]),
+        period=Period(instant=True, end_date="1999-12-31"),
+    )
+    different_id = Context(
+        c_id="some-other-c-id",
+        entity=test_context.entity,
+        period=test_context.period,
+    )
+
+    assert hash(test_context) == hash(same_id_different_entity)
+    assert hash(test_context) != hash(different_id)
+
+
+def test_axis_from_xml_rejects_malformed_dimension():
+    """Axis.from_xml() raises a clear error for an unrecognized dimension tag.
+
+    Only "explicitMember" and "typedMember" tags are valid XBRL dimensions.
+    """
+    elem = etree.fromstring("<xbrldi:notADimension xmlns:xbrldi='fake'/>")
+
+    with pytest.raises(ValueError, match="XBRL dimension not formatted correctly"):
+        Axis.from_xml(elem)
 
 
 @pytest.mark.parametrize(
@@ -210,6 +242,42 @@ def test_all_fact_ids():
     )
 
 
+def test_report_date_falls_back_to_certifying_official_date():
+    """FERC 714 filings have no report_date fact, unlike other forms.
+
+    Instance.__init__ falls back to the certifying_official_date fact in that
+    case -- reports with different publish dates sometimes share the same
+    certifying official date.
+    """
+    duration_facts = {
+        "certifying_official_date": [
+            Fact(
+                name="certifying_official_date",
+                c_id="context_1",
+                value="2022-08-12",
+            )
+        ]
+    }
+    contexts = {
+        "context_1": Context(
+            c_id="context_1",
+            entity=Entity(identifier="entity_1", dimensions=[]),
+            period=Period(instant=True, end_date="2023-01-01"),
+        ),
+    }
+
+    instance = Instance(
+        contexts,
+        instant_facts={},
+        duration_facts=duration_facts,
+        filing_name="test_instance",
+        taxonomy_version="form-714-2022-01-01.zip",
+        publication_time=datetime.datetime(2023, 10, 20, 0, 1, 2),
+    )
+
+    assert instance.report_date == datetime.date(2022, 8, 12)
+
+
 def test_get_instances_wrong_path(tmp_path):
     with pytest.raises(ValueError, match="Could not find XBRL instances"):
         get_instances(tmp_path / "bogus")
@@ -265,6 +333,39 @@ def test_get_instances_rejects_bare_file(tmp_path):
 
     with pytest.raises(ValueError, match="Expected a zipfile or directory"):
         get_instances(instance_file)
+
+
+def test_get_instances_from_bytesio():
+    """get_instances() supports an in-memory zip archive, not just a Path.
+
+    This is how PUDL always calls it in production (FercXbrlDatastore.get_filings
+    in pudl/src/pudl/extract/xbrl.py wraps every archive in io.BytesIO before
+    handing it off to this library), so it needs its own direct test rather than
+    relying only on the Path-to-zip case.
+    """
+    rssfeed = {
+        "some_filer": [
+            {
+                "filename": "filing.xbrl",
+                "rss_metadata": {"published_parsed": "2023-10-06T00:00:00+00:00"},
+                "taxonomy_zip_name": "form-1-2022-01-01.zip",
+            }
+        ]
+    }
+    zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(zip_bytes, mode="w") as zf:
+        zf.writestr("rssfeed", json.dumps(rssfeed))
+        zf.writestr("filing.xbrl", "<xbrl/>")
+    zip_bytes.seek(0)
+
+    instance_builders = get_instances(zip_bytes)
+
+    assert len(instance_builders) == 1
+    builder = instance_builders[0]
+    assert isinstance(builder, InstanceBuilder)
+    assert builder.name == "filing"
+    assert builder.publication_time == datetime.datetime(2023, 10, 6, 0, 0, 0)
+    assert builder.taxonomy_version == "form-1-2022-01-01.zip"
 
 
 def test_instances_with_dates(multi_filings):

--- a/tests/unit/instance_test.py
+++ b/tests/unit/instance_test.py
@@ -1,6 +1,7 @@
 """Test XBRL instance interface."""
 
 import datetime
+import json
 import logging
 from collections import Counter
 
@@ -133,7 +134,10 @@ def test_parse_instance(file_fixture, request):
     for column, fact_ids in expected_instant_facts.items():
         assert (
             len(
-                {(fact.c_id, fact.value) for fact in instance.instant_facts.get(column)}
+                {
+                    (fact.c_id, fact.value)
+                    for fact in instance.instant_facts.get(column, [])
+                }
                 - fact_ids
             )
             == 0
@@ -144,7 +148,7 @@ def test_parse_instance(file_fixture, request):
             len(
                 {
                     (fact.c_id, fact.value)
-                    for fact in instance.duration_facts.get(column)
+                    for fact in instance.duration_facts.get(column, [])
                 }
                 - fact_ids
             )
@@ -164,7 +168,6 @@ def test_all_fact_ids():
             Fact(
                 name="caveman_utterance",
                 c_id="context_2",
-                f_id="c2f2_id",
                 value="booga",
             ),
         ],
@@ -210,6 +213,58 @@ def test_all_fact_ids():
 def test_get_instances_wrong_path(tmp_path):
     with pytest.raises(ValueError, match="Could not find XBRL instances"):
         get_instances(tmp_path / "bogus")
+
+
+def test_get_instances_from_directory(tmp_path):
+    """get_instances() supports a directory of unzipped filings with an rssfeed.
+
+    This mirrors the zip-archive case, but reading the "rssfeed" metadata file
+    and individual filings from disk instead of from inside a zip -- useful for
+    local debugging, where it's convenient to edit filings directly rather than
+    repackaging them into a zip after every change.
+    """
+    (tmp_path / "filing.xbrl").write_text("<xbrl/>")
+    rssfeed = {
+        "some_filer": [
+            {
+                "filename": "filing.xbrl",
+                "rss_metadata": {"published_parsed": "2023-10-06T00:00:00+00:00"},
+                "taxonomy_zip_name": "form-1-2022-01-01.zip",
+            }
+        ]
+    }
+    (tmp_path / "rssfeed").write_text(json.dumps(rssfeed))
+
+    instance_builders = get_instances(tmp_path)
+
+    assert len(instance_builders) == 1
+    builder = instance_builders[0]
+    assert isinstance(builder, InstanceBuilder)
+    assert builder.name == "filing"
+    assert builder.publication_time == datetime.datetime(2023, 10, 6, 0, 0, 0)
+    assert builder.taxonomy_version == "form-1-2022-01-01.zip"
+
+
+def test_get_instances_from_directory_missing_rssfeed(tmp_path):
+    """A directory without an "rssfeed" file is rejected with a clear error."""
+    (tmp_path / "filing.xbrl").write_text("<xbrl/>")
+
+    with pytest.raises(ValueError, match="Could not find an 'rssfeed' metadata file"):
+        get_instances(tmp_path)
+
+
+def test_get_instances_rejects_bare_file(tmp_path):
+    """get_instances() doesn't support a single bare filing.
+
+    Unlike a directory, a single file has no room for an accompanying "rssfeed"
+    metadata file, so there's no way to determine its publication_time or
+    taxonomy_version.
+    """
+    instance_file = tmp_path / "filing.xbrl"
+    instance_file.write_text("<xbrl/>")
+
+    with pytest.raises(ValueError, match="Expected a zipfile or directory"):
+        get_instances(instance_file)
 
 
 def test_instances_with_dates(multi_filings):

--- a/tests/unit/taxonomy_test.py
+++ b/tests/unit/taxonomy_test.py
@@ -1,0 +1,52 @@
+"""Test XBRL taxonomy interface."""
+
+import pytest
+
+from ferc_xbrl_extractor.taxonomy import Concept, LinkRole
+
+
+@pytest.mark.parametrize(
+    "from_list,bad_list,exception_type,match",
+    [
+        (
+            Concept.from_list,
+            ["not_concept", {}, {}],
+            ValueError,
+            "First element should be 'concept'",
+        ),
+        (
+            Concept.from_list,
+            ["concept", "not_a_dict", {}],
+            TypeError,
+            "Second 2 elements should be dicts",
+        ),
+        (
+            LinkRole.from_list,
+            ["not_linkRole", {}],
+            ValueError,
+            "First element should be 'linkRole'",
+        ),
+        (
+            LinkRole.from_list,
+            ["linkRole", "not_a_dict"],
+            TypeError,
+            "Second element should be a dict",
+        ),
+    ],
+    ids=[
+        "concept-wrong-first-element",
+        "concept-non-dict-elements",
+        "link-role-wrong-first-element",
+        "link-role-non-dict-second-element",
+    ],
+)
+def test_from_list_rejects_malformed_arelle_input(
+    from_list, bad_list, exception_type, match
+):
+    """Concept.from_list() and LinkRole.from_list() validate Arelle's list structure.
+
+    Both expect Arelle to represent taxonomy structures as a list with a specific
+    literal string in the first position and dicts in the next 1-2 positions.
+    """
+    with pytest.raises(exception_type, match=match):
+        from_list(bad_list, concept_dict={})

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -1,7 +1,27 @@
 import pandas as pd
 from lxml.etree import XMLSyntaxError  # nosec: B410
 
-from ferc_xbrl_extractor.xbrl import process_batch
+from ferc_xbrl_extractor.xbrl import process_batch, process_instance
+
+
+def test_process_instance(mocker):
+    """process_instance() builds a dict of dataframes from the requested tables.
+
+    process_batch() is the only other caller, and only exercises this indirectly
+    via a ProcessPoolExecutor worker subprocess (see data_quality_test.py), whose
+    execution coverage.py doesn't capture -- so this needs its own direct test.
+    Table construction itself is FactTable.construct_dataframe()'s job (tested
+    separately), so this just checks the looping/dict-building contract.
+    """
+    instance = mocker.Mock(filing_name="test_filing")
+    fake_df = pd.DataFrame({"value": [1, 2, 3]})
+    table_def = mocker.Mock()
+    table_def.construct_dataframe.return_value = fake_df
+
+    result = process_instance(instance, table_defs={"my_table": table_def})
+
+    assert result == {"my_table": fake_df}
+    table_def.construct_dataframe.assert_called_once_with(instance)
 
 
 def test_process_batch(mocker):

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -59,7 +59,11 @@ def test_process_batch(mocker):
         for table in table_defs
     }
 
-    results = process_batch(instances, table_defs)
+    # MockInstanceBuilder and the list[str] table_defs are deliberately loose
+    # stand-ins: process_instance is mocked out below, so neither argument's real
+    # structure is ever exercised, and building real InstanceBuilder/FactTable
+    # fixtures here wouldn't test anything more.
+    results = process_batch(instances, table_defs)  # ty:ignore[invalid-argument-type]
 
     for table in table_defs:
         pd.testing.assert_frame_equal(


### PR DESCRIPTION
# Overview

See the updated release notes and README contents for additional documentation of what changed.

- After updating some repo infrastructure in #442 I tried to add type checking, and discovered there were quite a few issues, so I held off on trying to add that.
-This PR fixes the straightforward type annotation issues, and also a couple of bugs that the type checking highlighted.
- Many lines are `ty:ignore` comments due to Arelle being untyped -- we can add local stubs for the tiny subset of the Arelle API that we actually use, but that's a different PR.
- One of those bugs had to do with how we were constructing XBRL instances -- previously you could (in theory) build them from a ZipFile, a directory of filings, or an individual filing. But quite a while ago we realized you actually need the rssfeed metadata to differentiate between duplicate / updated records and also a stashed Taxonomy to apply to a whole batch of records. So the "directory of filings" and "single filing" instantiation paths have been broken for ages because they didn't offer those inputs, and we weren't actually ever using them in production. I removed the single-filing case, and attempted to fix the "directory of filings" case by assuming that the directory is exactly what you'd get if you unzipped one of our archives (including `rssfeed`).
- Another latent bug revealed by type checking was a case in which we assumed there would be a DuckDB path even if one hadn't been supplied, leading to a "no such method on None" error. Now we assume a default if one isn't provided. 
- Removes some 🧟 code `get_pandas_type()` which hasn't been used since 2022.
- Adds some new unit tests for things that weren't covered previously.
- Swaps a `df.apply()` for constructing `df.from_records()` in the hopes of speeding things up a little.
- Fixes what I think was a bug where we never escaped from an exponential backoff loop until `max_retries` because we had a `continue` where there should have been a `break`

In digging around a little more it seems like there may be some code that we don't actually use anywhere -- including the bit that had the `break` vs. `continue` bug -- since we never read Taxonomies from a URL and always assume we have archived inputs on disk. It might be worth doing an audit to see what code in here we actually use in either the `pudl-archiver` or `pudl` repos, and then deciding if we want to keep any of the code that we never use for completeness, etc. or if it's just cruft that we should trim.

# Testing

- All the unit and integration tests pass.
- Linting and formatting and type checking also pass.

# To-do list

- [x] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

