### PR TITLE
Complete typing, add py.typed and switch from ty to pyrefly

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -70,3 +70,11 @@ jobs:
       - name: Run linters
         run: |
           hatch run lint:check
+      - name: Type check with pyrefly
+        # Not covered by pre-commit.ci (see .pre-commit-config.yaml's "pyrefly" hook
+        # and its `ci.skip` entry), so it's enforced here instead.
+        run: |
+          hatch run types:check
+      - name: Check pyrefly type coverage
+        run: |
+          hatch run types:coverage-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,14 +44,14 @@ repos:
   # Formatters: hooks that re-write Python, TOML, YAML, and RST files
   ########################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.5
+    rev: v3.9.6
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,32 @@ repos:
         always_run: true
         entry: hatch run test:unit
 
+      # Type check with pyrefly. This has to be a local hook rather than an official
+      # pre-commit repo for pyrefly: running it through the hatch types environment
+      # (which already has every dependency installed) avoids needing network access
+      # to resolve the project's dependencies, which pre-commit.ci disables during
+      # hook execution -- but since pre-commit.ci can't run this hook either way (see
+      # `ci.skip` below), it's enforced in CI via dedicated steps in pytest.yml
+      # instead.
+      - id: pyrefly
+        name: pyrefly
+        stages: [pre-commit]
+        language: system
+        verbose: false
+        pass_filenames: false
+        always_run: true
+        entry: hatch run types:check
+      # Enforce the 85% type coverage floor recorded in [tool.hatch.envs.types.scripts]
+      # in pyproject.toml.
+      - id: pyrefly-coverage
+        name: pyrefly-coverage
+        stages: [pre-commit]
+        language: system
+        verbose: false
+        pass_filenames: false
+        always_run: true
+        entry: hatch run types:coverage-check
+
 ########################################################################################
 # Configuration for pre-commit.ci
 ########################################################################################
@@ -118,5 +144,11 @@ ci:
   autoupdate_branch: main
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
+<<<<<<< HEAD
   skip: [unit-tests]
+||||||| parent of a5ca313 (Switch from ty to pyrefly for type checking)
+  skip: [unit-tests, ty]
+=======
+  skip: [unit-tests, pyrefly, pyrefly-coverage]
+>>>>>>> a5ca313 (Switch from ty to pyrefly for type checking)
   submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -144,11 +144,5 @@ ci:
   autoupdate_branch: main
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
-<<<<<<< HEAD
-  skip: [unit-tests]
-||||||| parent of a5ca313 (Switch from ty to pyrefly for type checking)
-  skip: [unit-tests, ty]
-=======
   skip: [unit-tests, pyrefly, pyrefly-coverage]
->>>>>>> a5ca313 (Switch from ty to pyrefly for type checking)
   submodules: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ will use most:
 - `hatch run lint:format` -- reformat code and auto-fix lint issues with `ruff`.
 - `hatch run types:check` -- type check with `pyrefly` (separate, non-detached env
     from `lint`; see "Gotchas" below).
-- `hatch run types:coverage-check` -- enforce the 85% type-coverage floor on `src/`.
+- `hatch run types:coverage-check` -- enforce the 95% type-coverage floor on `src/`.
     `types:coverage-report` prints the same metric as a human-readable per-module
     table instead of raw JSON.
 - `hatch run docs:build` -- build the documentation with Sphinx into
@@ -67,9 +67,9 @@ change complete, and `hatch run lint:format` if it touched Python code.
     `pyproject.toml`) and applied automatically by `hatch run lint:format` / the
     `ruff-check` and `ruff-format` pre-commit hooks. Don't hand-format code to match a
     personal preference that conflicts with what `ruff format` produces.
-- Type checking uses `pyrefly` at the `basic` preset (`[tool.pyrefly]`), blocking in
-    pre-commit and CI, plus the 85% `src/` type-coverage floor above. New code should
-    be typed cleanly; suppress a genuine false positive with
+- Type checking uses `pyrefly` at the `default` preset (`[tool.pyrefly]`), blocking
+    in pre-commit and CI, plus the 95% `src/` type-coverage floor above. New code
+    should be typed cleanly; suppress a genuine false positive with
     `# pyrefly: ignore[rule-name]` and a short note explaining *why*, not just that
     it is one -- e.g. for `arelle-release` fields typed as plain `str` but narrower
     in our models, prefer letting `pydantic` validate the value at construction and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,18 +47,19 @@ will use most:
 - `hatch run lint:check` -- run `ruff check` and `ruff format --check`. Doesn't modify
     files.
 - `hatch run lint:format` -- reformat code and auto-fix lint issues with `ruff`.
-- `hatch run types:check` -- type check with `ty`. This is a separate, non-detached
-    env from `lint` (see "Gotchas" below) because `ty` needs the project's actual
-    runtime dependencies installed to resolve imports. Configured but **not currently
-    enforced** in pre-commit or CI (see "Code style" below) -- still fine to run
-    manually.
+- `hatch run types:check` -- type check with `pyrefly` (separate, non-detached env
+    from `lint`; see "Gotchas" below).
+- `hatch run types:coverage-check` -- enforce the 85% type-coverage floor on `src/`.
+    `types:coverage-report` prints the same metric as a human-readable per-module
+    table instead of raw JSON.
 - `hatch run docs:build` -- build the documentation with Sphinx into
     `docs/_build/html/`. Runs `doc8` first and fails on Sphinx warnings (`-W`).
 - `hatch run docs:check` -- run just the `doc8` formatting check on `docs/` and
     `README.rst`.
 
-An agent should run `hatch run lint:check` and `hatch run test:all` before
-considering a change complete, and `hatch run lint:format` if it touched Python code.
+An agent should run `hatch run lint:check`, `hatch run types:check`,
+`hatch run types:coverage-check`, and `hatch run test:all` before considering a
+change complete, and `hatch run lint:format` if it touched Python code.
 
 ## Code style
 
@@ -66,18 +67,15 @@ considering a change complete, and `hatch run lint:format` if it touched Python 
     `pyproject.toml`) and applied automatically by `hatch run lint:format` / the
     `ruff-check` and `ruff-format` pre-commit hooks. Don't hand-format code to match a
     personal preference that conflicts with what `ruff format` produces.
-- Type checking is done with `ty` (see `[tool.ty.src]`, which checks both `src` and
-    `tests`), enforced as a blocking check both locally (pre-commit) and in CI. New
-    code should be typed cleanly, with no new `# ty:ignore` comments to paper over
-    genuinely new type errors -- if you must suppress a real false positive, use a
-    `# ty: ignore[rule-name]` comment with a short note explaining *why*, not just
-    that it is one. `arelle-release` ships no `py.typed` marker but `ty` reads its
-    inline types anyway; most Arelle-related errors are real `X | None` unions, fixed
-    with `assert x is not None` rather than a suppression or a type stub package. For
-    `Literal`-typed fields populated from an untyped external `str`, prefer letting
-    `pydantic` validate the value at construction and suppress the resulting
-    `ty:ignore` with a comment to that effect, rather than chasing it statically.
-
+- Type checking uses `pyrefly` at the `basic` preset (`[tool.pyrefly]`), blocking in
+    pre-commit and CI, plus the 85% `src/` type-coverage floor above. New code should
+    be typed cleanly; suppress a genuine false positive with
+    `# pyrefly: ignore[rule-name]` and a short note explaining *why*, not just that
+    it is one -- e.g. for `arelle-release` fields typed as plain `str` but narrower
+    in our models, prefer letting `pydantic` validate the value at construction and
+    note that in the suppression comment, rather than chasing it statically. Only
+    raise the preset (e.g. to `strict`) as its own deliberate change, since it will
+    likely surface a batch of new errors at once.
 - Docstrings use the Google convention (`[tool.ruff.lint.pydocstyle]`).
 - Direct runtime `dependencies` in `pyproject.toml` should stay loosely
     version-constrained (lower bounds only, no upper bounds unless there's a known
@@ -159,25 +157,16 @@ considering a change complete, and `hatch run lint:format` if it touched Python 
     Python version via `uv python install`/`uv python pin`. Follow with
     `hatch env prune` to drop any environments already built against the old
     interpreter.
-- The `hatch run lint:*` environment (`[tool.hatch.envs.lint]`) is `detached = true`
-    for speed -- it does *not* install this package or its runtime dependencies, only
-    `ruff` and friends. That's fine for `ruff`, which only needs to parse syntax, but
-    it means `ty` cannot be run from that env (it needs pandas/pydantic/duckdb/etc.
-    actually installed to resolve imports). `ty` lives in its own non-detached
-    `[tool.hatch.envs.types]` env instead -- don't move it back into `lint` without
-    accounting for that.
+- `hatch run lint:*` is `detached = true` (no runtime deps installed), so `ruff`
+    works there but `pyrefly` can't -- it needs pandas/pydantic/duckdb/etc. installed
+    to resolve imports, hence its own non-detached `[tool.hatch.envs.types]` env.
 - `arelle-release` is a large, slow-to-install dependency (it's a full XBRL
     processor). Don't be surprised if `hatch env create` or CI takes a while the first
     time; this is normal, not a hang.
-- The pre-commit/`prek` `unit-tests` hook is a `language: system` local hook that
-    shells out to `hatch run test:unit`, and is in `ci.skip` in
-    `.pre-commit-config.yaml` since pre-commit.ci can't install this project's
-    dependencies -- it's enforced instead as a separate step in
-    `.github/workflows/pytest.yml`. If/when `ty` enforcement is added back (see "Code
-    style" above), give it the same treatment rather than using `ty`'s own
-    `astral-sh/ty-pre-commit` repo hook: that hook shells out to `uv check`, which
-    needs network access to resolve dependencies, and pre-commit.ci disables network
-    access during hook execution.
+- The pre-commit/`prek` `pyrefly`, `pyrefly-coverage`, and `unit-tests` hooks are
+    local `language: system` hooks, which pre-commit.ci can't run -- they're in its
+    `ci.skip` list and enforced instead as separate steps in
+    `.github/workflows/pytest.yml`.
 - `PUDL_DOCS_DISABLE_INTERSPHINX=1` speeds up doc builds and avoids failures when
     external intersphinx targets (numpy, pandas, etc. doc sites) are temporarily
     unreachable. CI sets this for the `docs` workflow; set it locally too if a docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,14 +66,18 @@ considering a change complete, and `hatch run lint:format` if it touched Python 
     `pyproject.toml`) and applied automatically by `hatch run lint:format` / the
     `ruff-check` and `ruff-format` pre-commit hooks. Don't hand-format code to match a
     personal preference that conflicts with what `ruff format` produces.
-- `ty` is configured (see `[tool.ty.src]`, which checks both `src` and `tests`) and
-    runnable via `hatch run types:check`, but is **not yet enforced** in pre-commit or
-    CI -- adopting it surfaced ~70 pre-existing errors (mostly around
-    `arelle-release`'s untyped API), and turning on enforcement plus deciding how to
-    handle that backlog (fix vs. suppress with `# ty: ignore[rule-name]`) is deferred
-    to a dedicated follow-up PR, kept out of unrelated changes here. Don't add
-    `ty: ignore` comments in this repo yet -- there's no enforcement to suppress
-    against, so they'd just be dead code until that follow-up PR lands.
+- Type checking is done with `ty` (see `[tool.ty.src]`, which checks both `src` and
+    `tests`), enforced as a blocking check both locally (pre-commit) and in CI. New
+    code should be typed cleanly, with no new `# ty:ignore` comments to paper over
+    genuinely new type errors -- if you must suppress a real false positive, use a
+    `# ty: ignore[rule-name]` comment with a short note explaining *why*, not just
+    that it is one. `arelle-release` ships no `py.typed` marker but `ty` reads its
+    inline types anyway; most Arelle-related errors are real `X | None` unions, fixed
+    with `assert x is not None` rather than a suppression or a type stub package. For
+    `Literal`-typed fields populated from an untyped external `str`, prefer letting
+    `pydantic` validate the value at construction and suppress the resulting
+    `ty:ignore` with a comment to that effect, rather than chasing it statically.
+
 - Docstrings use the Google convention (`[tool.ruff.lint.pydocstyle]`).
 - Direct runtime `dependencies` in `pyproject.toml` should stay loosely
     version-constrained (lower bounds only, no upper bounds unless there's a known
@@ -108,7 +112,11 @@ considering a change complete, and `hatch run lint:format` if it touched Python 
     `1.Y.Z (Unreleased)` section at the top of the file (create it, copying the
     format of the most recent released section, if it doesn't exist yet). Reference
     the relevant PR and/or issue number using the `sphinx-issues` roles, e.g.
-    `` :pr:`123` `` / `` :issue:`123` ``.
+    `` :pr:`123` `` / `` :issue:`123` ``. Keep each bullet to one concise,
+    intent-focused sentence -- describe *what changed and why*, not an enumeration
+    of every file or line touched; that's what the PR diff and commit messages are
+    for. This has been a recurring correction, so treat a multi-sentence bullet as a
+    sign to cut it down before committing.
 - Don't trust the file's existing top section number alone to know what the next
     version is -- it can lag behind reality. Run `git tag --sort=-v:refname | head -1`
     to find the actual most-recently-released version, and base the next number on

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,10 @@ FERC XBRL Extractor
    :target: https://github.com/catalyst-cooperative/ferc-xbrl-extractor/actions/workflows/pytest.yml
    :alt: pytest status
 
+.. image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/ferc-xbrl-extractor/pytest.yml?branch=main&label=pyrefly
+   :target: https://github.com/catalyst-cooperative/ferc-xbrl-extractor/actions/workflows/pytest.yml
+   :alt: pyrefly type checking status
+
 .. image:: https://img.shields.io/codecov/c/github/catalyst-cooperative/ferc-xbrl-extractor?style=flat&logo=codecov
    :target: https://codecov.io/gh/catalyst-cooperative/ferc-xbrl-extractor
    :alt: Codecov Test Coverage
@@ -251,7 +255,7 @@ Some of the available commands:
     hatch run lint:format
     # Type check with pyrefly
     hatch run types:check
-    # Check type annotation coverage stays at or above 85%
+    # Check type annotation coverage stays at or above 95%
     hatch run types:coverage-check
     # Print a human-readable type coverage report, module by module
     hatch run types:coverage-report
@@ -267,7 +271,7 @@ using `pyrefly <https://pyrefly.org/>`__, both configured in ``pyproject.toml``.
 typed codebase, not a strictly typed one. Annotating a function or variable is
 optional, but whatever annotations *are* present must be internally consistent, or
 ``pyrefly check`` will fail; it's a blocking check in both pre-commit and CI, along
-with a floor of 85% type annotation coverage across ``src/``, enforced by
+with a floor of 95% type annotation coverage across ``src/``, enforced by
 ``pyrefly coverage check``.
 
 PUDL Sustainers

--- a/README.rst
+++ b/README.rst
@@ -249,20 +249,26 @@ Some of the available commands:
     hatch run lint:check
     # Format code
     hatch run lint:format
-    # Type check with ty
+    # Type check with pyrefly
     hatch run types:check
+    # Check type annotation coverage stays at or above 85%
+    hatch run types:coverage-check
+    # Print a human-readable type coverage report, module by module
+    hatch run types:coverage-report
     # Build documentation
     hatch run docs:build
     # Check documentation formatting
     hatch run docs:check
 
 Code style is enforced using `ruff <https://docs.astral.sh/ruff/>`__, and type checked
-using `ty <https://docs.astral.sh/ty/>`__, both configured in ``pyproject.toml``.
+using `pyrefly <https://pyrefly.org/>`__, both configured in ``pyproject.toml``.
 
 **Type annotations are encouraged but not required everywhere** -- this is a gradually
 typed codebase, not a strictly typed one. Annotating a function or variable is
 optional, but whatever annotations *are* present must be internally consistent, or
-``ty check`` will fail; it's a blocking check in both pre-commit and CI.
+``pyrefly check`` will fail; it's a blocking check in both pre-commit and CI, along
+with a floor of 85% type annotation coverage across ``src/``, enforced by
+``pyrefly coverage check``.
 
 PUDL Sustainers
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ FERC XBRL Extractor
    :target: https://pypi.org/project/catalystcoop.ferc-xbrl-extractor/
    :alt: Supported Python Versions
 
-.. :image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff
    :alt: Formatted by ruff
 
@@ -258,6 +258,11 @@ Some of the available commands:
 
 Code style is enforced using `ruff <https://docs.astral.sh/ruff/>`__, and type checked
 using `ty <https://docs.astral.sh/ty/>`__, both configured in ``pyproject.toml``.
+
+**Type annotations are encouraged but not required everywhere** -- this is a gradually
+typed codebase, not a strictly typed one. Annotating a function or variable is
+optional, but whatever annotations *are* present must be internally consistent, or
+``ty check`` will fail; it's a blocking check in both pre-commit and CI.
 
 PUDL Sustainers
 ---------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,74 +11,66 @@ Release Notes
 Modernize tooling and packaging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Switched from mypy to pyrefly** for type checking. mypy had been declared as a
-  dependency but never actually wired into CI or pre-commit, so this is the first
-  time type checking is enforced here, at pyrefly's ``basic`` preset. Pre-existing
-  type gaps (mostly around ``arelle-release``, which ships without type stubs) are
-  suppressed inline with ``# pyrefly: ignore`` comments pending a follow-up typing
-  cleanup. An 85% type annotation coverage floor across ``src/`` is also enforced
-  via ``pyrefly coverage check``, with ``hatch run types:coverage-report``
-  available to print a human-readable, per-module breakdown of the same metric.
-* **Fixed real bugs that adopting a type checker surfaced**, rather than just
-  suppressing them: wrong return-type annotations on ``Instance.get_facts()`` and
-  ``process_batch()``, several functions typed narrower (``Path``-only) than
-  what they're actually called with, and missing ``None`` checks around
-  ``lxml`` element lookups. Also fixed a real crash this work turned up:
-  ``run_main()`` called ``convert_duckdb_into_parquet()`` unconditionally even
-  when ``--duckdb-path`` was never passed, which crashed with
-  ``duckdb.InvalidInputException`` -- including via the simplest example
-  command in the README. ``--duckdb-path`` now defaults to the sqlite path
-  with a ``.duckdb`` suffix instead.
 * **Switched from pre-commit to prek** as the hook runner, and added several new
   hooks: ``detect-secrets``, ``typos``, ``actionlint``, ``markdownlint-cli2``, and
-  ``taplo-format``, among others.
+  ``taplo-format``, among others. :pr:`442`
 * **Simplified packaging**: removed ``MANIFEST.in`` and the vestigial
   ``[tool.setuptools]`` configuration left over from before the switch to
-  hatchling.
-* **Migrated documentation hosting from Read the Docs to GitHub Pages**, publishing
-  only the latest version rather than a full version history.
+  hatchling. :pr:`442`
+* **Migrated documentation hosting from Read the Docs to GitHub Pages**, see
+  `https://docs.catalyst.coop/ferc-xbrl-extractor <https://docs.catalyst.coop/ferc-xbrl-extractor>`__.
+  :pr:`442`
 * **Switched the documentation theme from furo to pydata-sphinx-theme**, matching
   the look and feel of our other documentation sites, including shared social
-  links in the footer.
+  links in the footer. :pr:`442`
 * **Added ``llms.txt`` and per-page Markdown alternates** (via ``sphinx-llm``) to
-  make the documentation more easily consumable by LLM agents.
+  make the documentation more easily consumable by LLM agents. :pr:`442`
 * **Wired up CodeCov coverage reporting** with a repo-specific ``.codecov.yml``.
+  :pr:`442`
 * **Grouped Dependabot PRs** for both Python and GitHub Actions dependencies to
-  reduce bot PR noise.
+  reduce bot PR noise. :pr:`442`
 * Simplified the bot auto-merge workflow, and added a guard to the release
   workflow that verifies a release tag points at the current head of ``main``
-  before building.
+  before building. :pr:`442`
 * Switched release notifications from Slack to Zulip. :pr:`434`
 * Routine dependency and GitHub Actions version bumps.
 
-Fix ``get_instances()`` input handling
+Add static type checking with pyrefly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type checking is now enforced** using `pyrefly <https://pyrefly.org>`__ as a
+  blocking check in both pre-commit and CI, along with a 95% type annotation coverage
+  floor across ``src/`` -- ``hatch run types:coverage-report`` prints a human-readable,
+  per-module breakdown of that metric. The goal is to catch bugs, make future changes
+  safer, and help support IDEs and LLMs in parsing the codebase. The package now also
+  ships a ``py.typed`` marker indicating consumers can rely on inline types. :pr:`447`
+  :issue:`443`
+
+Bug fixes
+^^^^^^^^^
+
+Adding type checking (see above) surfaced several bugs.
 
 * **Fixed a long-standing crash in ``get_instances()``'s directory and bare-file
   input modes**, and removed the bare-file mode, which can't be fixed. Both had
   always crashed with a confusing ``TypeError``: they never supplied the
   ``InstanceBuilder`` constructor with a filing's publication time and taxonomy
   version, which are otherwise derived from an ``rssfeed`` metadata file FERC's
-  archiving process bundles into zip archives alongside the filings. Adopting
-  type checking surfaced the bug (a call missing required constructor
-  arguments). The **directory mode is now fixed for real**, reading that same
-  ``rssfeed`` file from disk instead of from inside a zip -- useful for local
-  debugging, where it's convenient to edit filings directly rather than
-  repackaging them into a zip after every change. The **bare single-file mode is
-  removed**: a lone filing has no room for an accompanying ``rssfeed`` file, so
-  there's no way to determine its publication time or taxonomy version. Both
-  input types now raise a clear ``ValueError`` on invalid input instead of
-  crashing.
-
-Resolve most Arelle/frictionless type-ignore comments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* **Resolved most remaining type-ignore comments with real narrowing fixes
-  rather than the type stub package originally proposed in** :issue:`443`
-  **(it turned out not to be the right tool for nearly any of them), then
-  raised overall type annotation coverage and shipped a ``py.typed`` marker**
-  so downstream consumers' type checkers can rely on this package's inline
-  types.
+  archiving process bundles into zip archives alongside the filings. The
+  **directory mode now works**, reading that same ``rssfeed`` file
+  from disk instead of from inside a zip -- useful for local debugging, where
+  it's convenient to edit filings directly rather than repackaging them into a
+  zip after every change. The **bare single-file mode is removed**: a lone
+  filing has no room for an accompanying ``rssfeed`` file, so there's no way to
+  determine its publication time or taxonomy version. Both input types now
+  raise a clear ``ValueError`` on invalid input instead of crashing. :pr:`444`
+* **Fixed a crash in ``run_main()``** that occurred whenever ``--duckdb-path``
+  wasn't passed on the CLI -- including via the simplest example command in
+  the README. ``--duckdb-path`` now defaults to the sqlite path with a
+  ``.duckdb`` suffix instead. :pr:`444`
+* **Fixed a taxonomy-loading retry loop** that could have raised a confusing
+  ``UnboundLocalError`` instead of a clear error if ever called with
+  ``max_retries < 1``. :pr:`447`
 
 Test suite cleanup
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -67,6 +67,16 @@ Fix ``get_instances()`` input handling
   input types now raise a clear ``ValueError`` on invalid input instead of
   crashing.
 
+Resolve most Arelle/frictionless ``ty:ignore`` comments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Resolved most remaining ``# ty:ignore`` comments with real narrowing fixes
+  rather than the type stub package originally proposed in** :issue:`443`
+  **(it turned out not to be the right tool for nearly any of them), then
+  raised overall type annotation coverage and shipped a ``py.typed`` marker**
+  so downstream consumers' type checkers can rely on this package's inline
+  types.
+
 Test suite cleanup
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,13 +11,16 @@ Release Notes
 Modernize tooling and packaging
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Switched from mypy to ty** for type checking. mypy had been declared as a
+* **Switched from mypy to pyrefly** for type checking. mypy had been declared as a
   dependency but never actually wired into CI or pre-commit, so this is the first
-  time type checking is enforced here. Pre-existing type gaps (mostly around
-  ``arelle-release``, which ships without type stubs) are suppressed inline with
-  ``# ty:ignore`` comments pending a follow-up typing cleanup.
-* **Fixed real bugs that adopting ty surfaced**, rather than just suppressing
-  them: wrong return-type annotations on ``Instance.get_facts()`` and
+  time type checking is enforced here, at pyrefly's ``basic`` preset. Pre-existing
+  type gaps (mostly around ``arelle-release``, which ships without type stubs) are
+  suppressed inline with ``# pyrefly: ignore`` comments pending a follow-up typing
+  cleanup. An 85% type annotation coverage floor across ``src/`` is also enforced
+  via ``pyrefly coverage check``, with ``hatch run types:coverage-report``
+  available to print a human-readable, per-module breakdown of the same metric.
+* **Fixed real bugs that adopting a type checker surfaced**, rather than just
+  suppressing them: wrong return-type annotations on ``Instance.get_facts()`` and
   ``process_batch()``, several functions typed narrower (``Path``-only) than
   what they're actually called with, and missing ``None`` checks around
   ``lxml`` element lookups. Also fixed a real crash this work turned up:
@@ -57,7 +60,7 @@ Fix ``get_instances()`` input handling
   ``InstanceBuilder`` constructor with a filing's publication time and taxonomy
   version, which are otherwise derived from an ``rssfeed`` metadata file FERC's
   archiving process bundles into zip archives alongside the filings. Adopting
-  ``ty`` for type checking surfaced the bug (a call missing required constructor
+  type checking surfaced the bug (a call missing required constructor
   arguments). The **directory mode is now fixed for real**, reading that same
   ``rssfeed`` file from disk instead of from inside a zip -- useful for local
   debugging, where it's convenient to edit filings directly rather than
@@ -67,10 +70,10 @@ Fix ``get_instances()`` input handling
   input types now raise a clear ``ValueError`` on invalid input instead of
   crashing.
 
-Resolve most Arelle/frictionless ``ty:ignore`` comments
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Resolve most Arelle/frictionless type-ignore comments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* **Resolved most remaining ``# ty:ignore`` comments with real narrowing fixes
+* **Resolved most remaining type-ignore comments with real narrowing fixes
   rather than the type stub package originally proposed in** :issue:`443`
   **(it turned out not to be the right tool for nearly any of them), then
   raised overall type annotation coverage and shipped a ``py.typed`` marker**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ tests = [
 ]
 types = [
     "lxml-stubs>=0.5", # Type stubs for lxml, which ships without inline types
-    "ty>=0.0.61", # Extremely fast Rust-based Python type checker, from Astral
+    "pyrefly>=1.1.1", # Fast Rust-based Python type checker, from Meta
 ]
 
 [tool.uv]
@@ -161,16 +161,23 @@ format = ["ruff format ./", "ruff check --fix ./"]
 all = ["check", "format"]
 
 [tool.hatch.envs.types]
-description = "Type check the code with ty"
-# Not detached, unlike the lint env above -- ty needs the project's actual runtime
-# dependencies (pydantic, pandas, etc.) installed to resolve imports, not just its
-# own tooling, so this env installs the project itself plus the "types" extra. Also
-# includes "tests" since [tool.ty.src] type checks the tests/ directory too, and
-# those tests import pytest, pytest-mock, etc.
+description = "Type check the code with pyrefly"
+# Not detached, unlike the lint env above -- pyrefly needs the project's actual
+# runtime dependencies (pydantic, pandas, etc.) installed to resolve imports, not
+# just its own tooling, so this env installs the project itself plus the "types"
+# extra. Also includes "tests" since [tool.pyrefly] type checks the tests/
+# directory too, and those tests import pytest, pytest-mock, etc.
 features = ["tests", "types"]
 
 [tool.hatch.envs.types.scripts]
-check = "ty check"
+check = "pyrefly check"
+# Coverage is only measured (and the 85% floor enforced) against src/, not tests/:
+# pyrefly can't derive stable per-module names for the test suite (no importable
+# package layout the same way src/ has), so a project-wide run reports those files
+# under a single "__unknown__" bucket and tanks the overall percentage. Restricting
+# to src/ also matches the 85% figure this floor was originally set from.
+coverage-check = "pyrefly coverage check --fail-under 85 src"
+coverage-report = "pyrefly coverage report src | python scripts/pyrefly_coverage_summary.py"
 
 [tool.hatch.envs.docs]
 description = "Build documentation with Sphinx"
@@ -299,10 +306,15 @@ exclude_lines = [
 max-line-length = 88
 ignore-path = ["docs/_build"]
 
-[tool.ty.src]
-include = ["src", "tests"]
+[tool.pyrefly]
+project-includes = ["src", "tests"]
+# "basic" is comparable in strictness to what ty enforced -- diagnostics for parse
+# errors and a small set of high-confidence, locally-fixable checks, but not the
+# stricter override/annotation-completeness/call-shape checks "strict" adds. Revisit
+# this over time as the codebase's annotation coverage grows.
+preset = "basic"
 
-# No [tool.ty.environment] python-version setting -- ty already infers it from
+# No explicit python-version setting -- pyrefly already infers it from
 # `project.requires-python` above, so pinning it again here would just be tracking
 # the same version in two places.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ tests = [
     "ruff>=0.15.22", # A very fast linter and autofixer
 ]
 types = [
-    "lxml-stubs>=0.5", # Type stubs for lxml, which ships without inline types
+    "types-lxml>=2026.1.1", # Type stubs for lxml, which ships without inline types.
     "pyrefly>=1.1.1", # Fast Rust-based Python type checker, from Meta
 ]
 
@@ -171,12 +171,11 @@ features = ["tests", "types"]
 
 [tool.hatch.envs.types.scripts]
 check = "pyrefly check"
-# Coverage is only measured (and the 85% floor enforced) against src/, not tests/:
+# Coverage is only measured (and the 95% floor enforced) against src/, not tests/:
 # pyrefly can't derive stable per-module names for the test suite (no importable
 # package layout the same way src/ has), so a project-wide run reports those files
-# under a single "__unknown__" bucket and tanks the overall percentage. Restricting
-# to src/ also matches the 85% figure this floor was originally set from.
-coverage-check = "pyrefly coverage check --fail-under 85 src"
+# under a single "__unknown__" bucket and tanks the overall percentage.
+coverage-check = "pyrefly coverage check --fail-under 95 src"
 coverage-report = "pyrefly coverage report src | python scripts/pyrefly_coverage_summary.py"
 
 [tool.hatch.envs.docs]
@@ -308,15 +307,7 @@ ignore-path = ["docs/_build"]
 
 [tool.pyrefly]
 project-includes = ["src", "tests"]
-# "basic" is comparable in strictness to what ty enforced -- diagnostics for parse
-# errors and a small set of high-confidence, locally-fixable checks, but not the
-# stricter override/annotation-completeness/call-shape checks "strict" adds. Revisit
-# this over time as the codebase's annotation coverage grows.
-preset = "basic"
-
-# No explicit python-version setting -- pyrefly already infers it from
-# `project.requires-python` above, so pinning it again here would just be tracking
-# the same version in two places.
+preset = "default"
 
 [tool.pytest]
 testpaths = ["./"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,12 +308,6 @@ ignore-path = ["docs/_build"]
 [tool.pyrefly]
 project-includes = ["src", "tests"]
 preset = "default"
-# Without this, pyrefly falls back to querying `which python3`/`python` on PATH for
-# python-version/site-package-path, which picks up whatever interpreter happens to
-# be first on PATH (e.g. system Python) rather than this project's own venv --
-# pinning it here makes pyrefly's resolution deterministic across the hatch env,
-# a plain CLI invocation, and editor/IDE integrations alike.
-python-interpreter-path = ".venv/bin/python3"
 
 [tool.pytest]
 testpaths = ["./"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -308,6 +308,12 @@ ignore-path = ["docs/_build"]
 [tool.pyrefly]
 project-includes = ["src", "tests"]
 preset = "default"
+# Without this, pyrefly falls back to querying `which python3`/`python` on PATH for
+# python-version/site-package-path, which picks up whatever interpreter happens to
+# be first on PATH (e.g. system Python) rather than this project's own venv --
+# pinning it here makes pyrefly's resolution deterministic across the hatch env,
+# a plain CLI invocation, and editor/IDE integrations alike.
+python-interpreter-path = ".venv/bin/python3"
 
 [tool.pytest]
 testpaths = ["./"]

--- a/scripts/pyrefly_coverage_summary.py
+++ b/scripts/pyrefly_coverage_summary.py
@@ -1,0 +1,54 @@
+"""Render `pyrefly coverage report`'s JSON as a human-readable table.
+
+Reads the JSON report from stdin (i.e. run as
+``pyrefly coverage report src | python scripts/pyrefly_coverage_summary.py``) and
+prints one row per module -- typable symbol count, how many are untyped, and the
+resulting coverage percentage -- followed by the same metrics summed across the
+whole project.
+"""
+
+import json
+import sys
+
+
+def _coverage(n_typable: int, n_untyped: int) -> float:
+    if n_typable == 0:
+        return 100.0
+    return 100.0 * (n_typable - n_untyped) / n_typable
+
+
+def main() -> None:
+    """Read a pyrefly coverage JSON report from stdin and print a summary table."""
+    report = json.load(sys.stdin)
+
+    rows = sorted(
+        (
+            module["name"],
+            module["n_typable"],
+            module["n_untyped"],
+            _coverage(module["n_typable"], module["n_untyped"]),
+        )
+        for module in report["module_reports"]
+    )
+
+    name_width = max((len(name) for name, *_ in rows), default=len("Module"))
+    header = (
+        f"{'Module':<{name_width}}  {'Typable':>7}  {'Untyped':>7}  {'Coverage':>8}"
+    )
+    print(header)
+    print("-" * len(header))
+    for name, n_typable, n_untyped, coverage in rows:
+        print(
+            f"{name:<{name_width}}  {n_typable:>7}  {n_untyped:>7}  {coverage:>7.1f}%"
+        )
+
+    summary = report["summary"]
+    print("-" * len(header))
+    print(
+        f"{'TOTAL':<{name_width}}  {summary['n_typable']:>7}  "
+        f"{summary['n_untyped']:>7}  {summary['coverage']:>7.1f}%"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -237,4 +237,4 @@ class Metadata(BaseModel):
 
         # Arelle types `balance` as a plain `str`, wider than our `Literal["credit",
         # "debit"] | None` -- pydantic validates the actual value at construction time.
-        return cls(**concept_metadata)  # pyrefly: ignore[missing-argument]
+        return cls(**concept_metadata)

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -2,7 +2,7 @@
 
 import time
 from pathlib import Path
-from typing import BinaryIO, Literal, cast
+from typing import Any, BinaryIO, Literal, cast
 
 import pydantic
 import stringcase
@@ -45,12 +45,16 @@ def _taxonomy_view(
         max_retries: Maximum number of load attempts before giving up and
             re-raising the last ``FileExistsError``.
     """
+    if max_retries < 1:
+        raise ValueError(f"max_retries must be at least 1, got {max_retries}")
+
     cntlr = Cntlr.Cntlr()
     cntlr.startLogging(logFileName="logToPrint")
     # Arelle types `logger` as `Logger | None` since it's unset until `startLogging()`
     # runs -- which we just did, so it's populated from here on.
     assert cntlr.logger is not None
     model_manager = ModelManager.initialize(cntlr)
+    taxonomy: ModelXbrl.ModelXbrl | None = None
     for try_count in range(max_retries):
         try:
             cntlr.logger.debug(f"Try #{try_count}: {taxonomy_source=}")
@@ -63,6 +67,10 @@ def _taxonomy_view(
             cntlr.logger.warning(f"Failed try #{try_count}, retrying in {backoff}s")
             time.sleep(backoff)
 
+    # The loop above always either assigns `taxonomy` and breaks, or raises on its
+    # final iteration -- the guard above guarantees at least one iteration -- but a
+    # static checker can't derive that from `range(max_retries)` alone.
+    assert taxonomy is not None
     view = ViewRelationshipSet(taxonomy, "taxonomy.json", "roles", None, None, None)
     view.view(XbrlConst.parentChild, None, None, None)
 
@@ -150,7 +158,7 @@ class Metadata(BaseModel):
         """
         # Get name and convert to snakecase to match output DB
         name = stringcase.snakecase(concept.name)
-        concept_metadata = {"name": name}
+        concept_metadata: dict[str, Any] = {"name": name}
 
         # A loaded Concept always belongs to a ModelXbrl -- only unset on freestanding
         # prototype objects, which don't reach this code path.
@@ -229,4 +237,4 @@ class Metadata(BaseModel):
 
         # Arelle types `balance` as a plain `str`, wider than our `Literal["credit",
         # "debit"] | None` -- pydantic validates the actual value at construction time.
-        return cls(**concept_metadata)  # ty:ignore[invalid-argument-type]
+        return cls(**concept_metadata)  # pyrefly: ignore[missing-argument]

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -2,17 +2,20 @@
 
 import time
 from pathlib import Path
-from typing import BinaryIO, Literal
+from typing import BinaryIO, Literal, cast
 
 import pydantic
 import stringcase
 from arelle import Cntlr, FileSource, ModelManager, ModelXbrl, XbrlConst
 from arelle.ModelDtsObject import ModelConcept
+from arelle.ModelObject import ModelObject
 from arelle.ViewFileRelationshipSet import ViewRelationshipSet
 from pydantic import BaseModel
 
 
-def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: int = 7):
+def _taxonomy_view(
+    taxonomy_source: str | FileSource.FileSource, max_retries: int = 7
+) -> tuple[ModelXbrl.ModelXbrl, ViewRelationshipSet]:
     """Use Arelle to load a taxonomy and build its parent-child relationship view.
 
     As it parses a taxonomy, Arelle downloads the schema/linkbase files it
@@ -44,6 +47,9 @@ def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: in
     """
     cntlr = Cntlr.Cntlr()
     cntlr.startLogging(logFileName="logToPrint")
+    # Arelle types `logger` as `Logger | None` since it's unset until `startLogging()`
+    # runs -- which we just did, so it's populated from here on.
+    assert cntlr.logger is not None
     model_manager = ModelManager.initialize(cntlr)
     for try_count in range(max_retries):
         try:
@@ -63,7 +69,9 @@ def _taxonomy_view(taxonomy_source: str | FileSource.FileSource, max_retries: in
     return taxonomy, view
 
 
-def load_taxonomy(path: str | Path):
+def load_taxonomy(
+    path: str | Path,
+) -> tuple[ModelXbrl.ModelXbrl, ViewRelationshipSet]:
     """Load XBRL taxonomy, and parse relationships.
 
     Args:
@@ -74,7 +82,9 @@ def load_taxonomy(path: str | Path):
     return _taxonomy_view(source)
 
 
-def load_taxonomy_from_archive(taxonomy_archive: BinaryIO, entry_point: str | Path):
+def load_taxonomy_from_archive(
+    taxonomy_archive: BinaryIO, entry_point: str | Path
+) -> tuple[ModelXbrl.ModelXbrl, ViewRelationshipSet]:
     """Load an XBRL taxonomy from a zipfile archive.
 
     Args:
@@ -142,6 +152,9 @@ class Metadata(BaseModel):
         name = stringcase.snakecase(concept.name)
         concept_metadata = {"name": name}
 
+        # A loaded Concept always belongs to a ModelXbrl -- only unset on freestanding
+        # prototype objects, which don't reach this code path.
+        assert concept.modelXbrl is not None
         references = concept.modelXbrl.relationshipSet(
             XbrlConst.conceptReference
         ).fromModelObject(concept)
@@ -150,15 +163,28 @@ class Metadata(BaseModel):
         reference_dict = {}
         for reference in references:
             reference = reference.toModelObject
+            assert reference is not None
+            assert reference.modelXbrl is not None
             reference_name = reference.modelXbrl.roleTypeDefinition(reference.role)
-            # Several values can make up a single reference. Create a dictionary with these
+            # Several values can make up a single reference. Create a dictionary with these.
+            # iterchildren() is inherited from lxml's generic `_Element`, but Arelle
+            # registers its own element class, so children are actually `ModelObject`s
+            # with `localName`/`stringValue` attributes lxml's stubs don't know about.
             part_dict = {
-                part.localName: part.stringValue for part in reference.iterchildren()
+                cast(ModelObject, part).localName: cast(ModelObject, part).stringValue
+                for part in reference.iterchildren()
             }
 
             # There can also be several references with the same name, so store in list
             if reference_name in reference_dict:
-                reference_dict[reference_name].append(part_dict)
+                # `reference_dict[reference_name]` can be flattened to a bare `str`
+                # below (see comment), so its declared type is `list[dict] | str`, but
+                # `ty` can't confirm that a *previously* flattened entry never recurs
+                # here. Pre-existing behavior, unrelated to Arelle's own typing --
+                # flagged separately as a possible latent bug, not fixed by this change.
+                reference_dict[reference_name].append(
+                    part_dict
+                )  # ty:ignore[unresolved-attribute]
             else:
                 reference_dict[reference_name] = [part_dict]
 
@@ -180,9 +206,14 @@ class Metadata(BaseModel):
 
         calculation_list = []
         for calculation in calculations:
+            assert calculation.toModelObject is not None
+            # summation-item relationships always link concept to concept, but
+            # `toModelObject` is typed as the generic `ModelObject` base class, which
+            # doesn't declare `.name` -- only its `ModelConcept` subclass does.
+            calc_concept = cast(ModelConcept, calculation.toModelObject)
             calculation_list.append(
                 {
-                    "name": stringcase.snakecase(calculation.toModelObject.name),
+                    "name": stringcase.snakecase(calc_concept.name),
                     "weight": calculation.weight,
                 }
             )
@@ -190,4 +221,6 @@ class Metadata(BaseModel):
         concept_metadata["calculations"] = calculation_list
         concept_metadata["balance"] = concept.balance
 
-        return cls(**concept_metadata)
+        # Arelle types `balance` as a plain `str`, wider than our `Literal["credit",
+        # "debit"] | None` -- pydantic validates the actual value at construction time.
+        return cls(**concept_metadata)  # ty:ignore[invalid-argument-type]

--- a/src/ferc_xbrl_extractor/arelle_interface.py
+++ b/src/ferc_xbrl_extractor/arelle_interface.py
@@ -177,14 +177,20 @@ class Metadata(BaseModel):
 
             # There can also be several references with the same name, so store in list
             if reference_name in reference_dict:
+                existing_entry = reference_dict[reference_name]
                 # `reference_dict[reference_name]` can be flattened to a bare `str`
-                # below (see comment), so its declared type is `list[dict] | str`, but
-                # `ty` can't confirm that a *previously* flattened entry never recurs
-                # here. Pre-existing behavior, unrelated to Arelle's own typing --
-                # flagged separately as a possible latent bug, not fixed by this change.
-                reference_dict[reference_name].append(
-                    part_dict
-                )  # ty:ignore[unresolved-attribute]
+                # below (see comment) the *first* time a reference_name occurs with a
+                # single, name-matching part. If that same reference_name recurs after
+                # being flattened, this logic can't represent both shapes at once --
+                # turn what would otherwise be a cryptic `AttributeError` into a
+                # legible one so this gets noticed and investigated if it ever
+                # actually happens with real FERC filing data.
+                assert isinstance(existing_entry, list), (
+                    f"Reference {reference_name!r} was flattened to a single value for "
+                    "an earlier reference on this concept, but recurred here -- the "
+                    "flattening logic below can't represent both shapes."
+                )
+                existing_entry.append(part_dict)
             else:
                 reference_dict[reference_name] = [part_dict]
 

--- a/src/ferc_xbrl_extractor/cli.py
+++ b/src/ferc_xbrl_extractor/cli.py
@@ -19,7 +19,7 @@ from ferc_xbrl_extractor import xbrl
 from ferc_xbrl_extractor.helpers import get_logger
 
 
-def parse():
+def parse() -> argparse.Namespace:
     """Process base commands from the CLI."""
     parser = argparse.ArgumentParser(
         description="Extract data from XBRL filings to SQLite or DuckDB."
@@ -97,14 +97,18 @@ def parse():
     return parser.parse_args()
 
 
-def write_to_sqlite(sqlite_engine: Engine, table_name: str, table_data: pd.DataFrame):
+def write_to_sqlite(
+    sqlite_engine: Engine, table_name: str, table_data: pd.DataFrame
+) -> None:
     """Write one table to a SQLite database."""
     # Write to SQLite
     with sqlite_engine.begin() as sqlite_conn:
         table_data.to_sql(table_name, sqlite_conn, if_exists="replace")
 
 
-def write_to_duckdb(duckdb_path: str | Path, table_name: str, table_data: pd.DataFrame):
+def write_to_duckdb(
+    duckdb_path: str | Path, table_name: str, table_data: pd.DataFrame
+) -> None:
     """Write one table to a duckdb database."""
     table_data = table_data.reset_index()
     with duckdb.connect(duckdb_path) as duckdb_conn:
@@ -143,7 +147,7 @@ def run_main(
     logfile: Path | None,
     requested_tables: list[str] | None = None,
     instance_pattern: str = r"",
-):
+) -> None:
     """Log setup, taxonomy finding, and SQL IO."""
     logger = get_logger("ferc_xbrl_extractor")
     logger.setLevel(loglevel)
@@ -195,7 +199,7 @@ def run_main(
     write_datapackage(datapackage=datapackage_parquet, output_dir=parquet_dir)
 
 
-def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path):
+def convert_duckdb_into_parquet(duckdb_path: Path, parquet_dir: Path) -> None:
     """Convert the duckdb into a directory of parquet files.
 
     We do this using COPY. We tried using EXPORT DATABASE, but it unfortunately
@@ -237,7 +241,7 @@ def convert_and_validate_datapackage_sqlite_to_parquet(datapackage_path: Path) -
     return datapackage
 
 
-def write_datapackage(datapackage: dict, output_dir: Path):
+def write_datapackage(datapackage: dict, output_dir: Path) -> None:
     """Write a datapackage to <output_dir>/datapackage.json.
 
     output_dir must exist.
@@ -246,7 +250,7 @@ def write_datapackage(datapackage: dict, output_dir: Path):
         f.write(json.dumps(datapackage, indent=2))
 
 
-def main():
+def main() -> None:
     """Parse arguments and pass to run_main."""
     return run_main(**vars(parse()))
 

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -2,7 +2,7 @@
 
 import re
 from collections.abc import Callable
-from typing import Any, Union
+from typing import Any, Literal, Union
 
 import pandas as pd
 import pydantic
@@ -340,7 +340,7 @@ class Resource(BaseModel):
 
         return resource_schema
 
-    def get_period_type(self):
+    def get_period_type(self) -> Literal["instant", "duration"]:
         """Helper function to get period type from schema."""
         period_type = "instant" if "date" in self.schema_.primary_key else "duration"
         return period_type

--- a/src/ferc_xbrl_extractor/datapackage.py
+++ b/src/ferc_xbrl_extractor/datapackage.py
@@ -1,5 +1,6 @@
 """Define structures for creating a datapackage descriptor."""
 
+import logging
 import re
 from collections.abc import Callable
 from typing import Any, Literal, Union
@@ -13,7 +14,7 @@ from ferc_xbrl_extractor.helpers import get_logger
 from ferc_xbrl_extractor.instance import Instance
 from ferc_xbrl_extractor.taxonomy import Concept, LinkRole, Taxonomy
 
-logger = get_logger(__name__)
+logger: logging.Logger = get_logger(__name__)
 
 
 class Field(BaseModel):
@@ -48,7 +49,7 @@ class Field(BaseModel):
         return hash(self.name)
 
 
-ENTITY_ID = Field(
+ENTITY_ID: Field = Field(
     name="entity_id",
     title="Entity Identifier",
     type="string",
@@ -58,14 +59,14 @@ ENTITY_ID = Field(
 Field representing an entity ID (Present in all tables).
 """
 
-FILING_NAME = Field(
+FILING_NAME: Field = Field(
     name="filing_name", title="Filing Name", type="string", description="Name of filing"
 )
 """
 Field representing the filing name (Present in all tables).
 """
 
-PUBLICATION_TIME = Field(
+PUBLICATION_TIME: Field = Field(
     name="publication_time",
     title="Publication Time",
     type="date",
@@ -75,7 +76,7 @@ PUBLICATION_TIME = Field(
 Field representing the publication time (injected into all tables).
 """
 
-START_DATE = Field(
+START_DATE: Field = Field(
     name="start_date",
     title="Start Date",
     type="date",
@@ -85,7 +86,7 @@ START_DATE = Field(
 Field representing start date (Present in all duration tables).
 """
 
-END_DATE = Field(
+END_DATE: Field = Field(
     name="end_date",
     title="End Date",
     type="date",
@@ -95,7 +96,7 @@ END_DATE = Field(
 Field representing end date (Present in all duration tables).
 """
 
-INSTANT_DATE = Field(
+INSTANT_DATE: Field = Field(
     name="date", title="Instant Date", type="date", description="Date of instant period"
 )
 """
@@ -139,12 +140,14 @@ CONVERT_DTYPES: dict[str, Callable] = {
 Map callables to schema field type to convert parsed values (Data Package `field.type`).
 """
 
-TABLE_NAME_PATTERN = re.compile(r"(.+)\s+-\s+Schedule\s+-\s+(.*)", re.I)
+TABLE_NAME_PATTERN: re.Pattern[str] = re.compile(
+    r"(.+)\s+-\s+Schedule\s+-\s+(.*)", re.I
+)
 """
 Simple regex pattern used to clean up table names.
 """
 
-UPPERCASE_WORD_PATTERN = re.compile("[^A-Z][A-Z]([A-Z]+)")
+UPPERCASE_WORD_PATTERN: re.Pattern[str] = re.compile("[^A-Z][A-Z]([A-Z]+)")
 """
 Regex pattern to find fully uppercase words.
 
@@ -397,16 +400,20 @@ class FactTable:
 
     def __init__(self, schema: Schema, period_type: str):
         """Create FactTable and prepare for constructing dataframe."""
-        self.schema = schema
+        self.schema: Schema = schema
         # Map column names to function to convert parsed values
-        self.columns = {field.name: field.type_ for field in schema.fields}
-        self.axes = [name for name in schema.primary_key if name.endswith("axis")]
-        self.data_columns = [
+        self.columns: dict[str, str] = {
+            field.name: field.type_ for field in schema.fields
+        }
+        self.axes: list[str] = [
+            name for name in schema.primary_key if name.endswith("axis")
+        ]
+        self.data_columns: list[str] = [
             field.name
             for field in schema.fields
             if field.name not in schema.primary_key
         ]
-        self.instant = period_type == "instant"
+        self.instant: bool = period_type == "instant"
 
     def construct_dataframe(self, instance: Instance) -> pd.DataFrame:
         """Construct dataframe from a parsed XBRL instance.

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -4,6 +4,7 @@ import datetime
 import io
 import itertools
 import json
+import logging
 import zipfile
 from collections import Counter, defaultdict
 from collections.abc import Iterator
@@ -277,18 +278,18 @@ class Instance:
             filing_name: Name of parsed filing.
             publication_time: the time at which the filing was made available online.
         """
-        self.logger = get_logger(__name__)
-        self.taxonomy_version = taxonomy_version
-        self.instant_facts = instant_facts
-        self.duration_facts = duration_facts
-        self.fact_id_counts = Counter(
+        self.logger: logging.Logger = get_logger(__name__)
+        self.taxonomy_version: str = taxonomy_version
+        self.instant_facts: dict[str, list[Fact]] = instant_facts
+        self.duration_facts: dict[str, list[Fact]] = duration_facts
+        self.fact_id_counts: Counter[str] = Counter(
             f.f_id()
             for f in itertools.chain.from_iterable(
                 (instant_facts | duration_facts).values()
             )
         )
-        self.total_facts = len(self.fact_id_counts)
-        self.duplicated_fact_ids = [
+        self.total_facts: int = len(self.fact_id_counts)
+        self.duplicated_fact_ids: list[str] = [
             f_id
             for f_id, _ in itertools.takewhile(
                 lambda c: c[1] >= 2, self.fact_id_counts.most_common()
@@ -300,12 +301,14 @@ class Instance:
             )
         self.used_fact_ids: set[str] = set()
 
-        self.filing_name = filing_name
-        self.contexts = contexts
+        self.filing_name: str = filing_name
+        self.contexts: dict[str, Context] = contexts
         if "report_date" in duration_facts:
             report_date_value = duration_facts["report_date"][0].value
             assert report_date_value is not None
-            self.report_date = datetime.date.fromisoformat(report_date_value)
+            self.report_date: datetime.date = datetime.date.fromisoformat(
+                report_date_value
+            )
         else:
             # FERC 714 workaround - though sometimes reports with different
             # publish dates have the same certifying official date.
@@ -313,10 +316,10 @@ class Instance:
                 0
             ].value
             assert certifying_official_date_value is not None
-            self.report_date = datetime.date.fromisoformat(
+            self.report_date: datetime.date = datetime.date.fromisoformat(
                 certifying_official_date_value
             )
-        self.publication_time = publication_time
+        self.publication_time: datetime.datetime = publication_time
 
     def get_facts(
         self, instant: bool, concept_names: list[str], primary_key: list[str]
@@ -357,10 +360,10 @@ class InstanceBuilder:
             name: Name of filing.
             publication_time: Time this filing was published.
         """
-        self.name = name
-        self.file = file_info
-        self.publication_time = publication_time
-        self.taxonomy_version = taxonomy_version
+        self.name: str = name
+        self.file: str | BinaryIO = file_info
+        self.publication_time: datetime.datetime = publication_time
+        self.taxonomy_version: str = taxonomy_version
 
     def parse(self, fact_prefix: str = "ferc") -> Instance:
         """Parse a single XBRL instance using XML library directly.

--- a/src/ferc_xbrl_extractor/instance.py
+++ b/src/ferc_xbrl_extractor/instance.py
@@ -41,12 +41,14 @@ class Period(BaseModel):
         """Construct Period from XML element."""
         instant = elem.find(f"{{{XBRL_INSTANCE}}}instant")
         if instant is not None:
+            assert instant.text is not None
             return cls(instant=True, end_date=instant.text)
 
         start_date_elem = elem.find(f"{{{XBRL_INSTANCE}}}startDate")
         end_date_elem = elem.find(f"{{{XBRL_INSTANCE}}}endDate")
         assert start_date_elem is not None
         assert end_date_elem is not None
+        assert end_date_elem.text is not None
         return cls(
             instant=False,
             start_date=start_date_elem.text,
@@ -87,10 +89,13 @@ class Axis(BaseModel):
     @classmethod
     def from_xml(cls, elem: Element) -> "Axis":
         """Construct Axis from XML element."""
+        # A parsed element's tag is always a plain str; only an as-yet-unparsed,
+        # freshly-constructed element could have a QName tag instead.
+        assert isinstance(elem.tag, str)
         if elem.tag.endswith("explicitMember"):
             return cls(
                 name=elem.attrib["dimension"],
-                value=elem.text,
+                value=elem.text or "",
                 dimension_type=DimensionType.EXPLICIT,
             )
 
@@ -98,7 +103,7 @@ class Axis(BaseModel):
             dim = elem[0]
             return cls(
                 name=elem.attrib["dimension"],
-                value=dim.text if dim.text else "",
+                value=dim.text or "",
                 dimension_type=DimensionType.TYPED,
             )
 
@@ -126,6 +131,7 @@ class Entity(BaseModel):
 
         identifier_elem = elem.find(f"{{{XBRL_INSTANCE}}}identifier")
         assert identifier_elem is not None
+        assert identifier_elem.text is not None
 
         return cls(
             identifier=identifier_elem.text,
@@ -227,6 +233,9 @@ class Fact(BaseModel):
         """Construct Fact from XML element."""
         # Get prefix from namespace map to strip from fact name
         prefix = f"{{{elem.nsmap[elem.prefix]}}}"
+        # A parsed element's tag is always a plain str; only an as-yet-unparsed,
+        # freshly-constructed element could have a QName tag instead.
+        assert isinstance(elem.tag, str)
         return cls(
             name=stringcase.snakecase(elem.tag.replace(prefix, "")),  # Strip prefix
             c_id=elem.attrib["contextRef"],

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -41,8 +41,9 @@ class XBRLType(BaseModel):
         # Arelle types `baseXsdType` as a plain `str`, wider than our `base` Literal --
         # pydantic validates the actual value at construction time.
         return cls(
-            name=arelle_type.name, base=arelle_type.baseXsdType.lower()
-        )  # pyrefly: ignore[bad-argument-type]
+            name=arelle_type.name,
+            base=arelle_type.baseXsdType.lower(),  # pyrefly: ignore[bad-argument-type]
+        )
 
     def get_schema_type(self) -> str:
         """Return string specifying type for a frictionless table schema."""

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -42,7 +42,7 @@ class XBRLType(BaseModel):
         # pydantic validates the actual value at construction time.
         return cls(
             name=arelle_type.name, base=arelle_type.baseXsdType.lower()
-        )  # ty:ignore[invalid-argument-type]
+        )  # pyrefly: ignore[bad-argument-type]
 
     def get_schema_type(self) -> str:
         """Return string specifying type for a frictionless table schema."""
@@ -113,7 +113,7 @@ class Concept(BaseModel):
             type=XBRLType.from_arelle_type(concept.type),
             # Arelle types `periodType` as a plain `str`, wider than our Literal --
             # pydantic validates the actual value at construction time.
-            period_type=concept.periodType,  # ty:ignore[invalid-argument-type]
+            period_type=concept.periodType,  # pyrefly: ignore[bad-argument-type]
             child_concepts=[
                 Concept.from_list(concept, concept_dict) for concept in concept_list[3:]
             ],

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -37,7 +37,12 @@ class XBRLType(BaseModel):
     @classmethod
     def from_arelle_type(cls, arelle_type: ModelType) -> "XBRLType":
         """Construct XBRLType class from arelle ModelType."""
-        return cls(name=arelle_type.name, base=arelle_type.baseXsdType.lower())
+        assert arelle_type.name is not None
+        # Arelle types `baseXsdType` as a plain `str`, wider than our `base` Literal --
+        # pydantic validates the actual value at construction time.
+        return cls(
+            name=arelle_type.name, base=arelle_type.baseXsdType.lower()
+        )  # ty:ignore[invalid-argument-type]
 
     def get_schema_type(self) -> str:
         """Return string specifying type for a frictionless table schema."""
@@ -94,12 +99,21 @@ class Concept(BaseModel):
 
         concept = concept_dict[concept_list[1]["name"]]
 
+        assert concept.name is not None
+        standard_label = concept.label(XbrlConst.standardLabel)
+        assert standard_label is not None
+        documentation = concept.label(XbrlConst.documentationLabel)
+        assert documentation is not None
+        assert concept.type is not None
+
         return cls(
             name=concept.name,
-            standard_label=concept.label(XbrlConst.standardLabel),
-            documentation=concept.label(XbrlConst.documentationLabel),
+            standard_label=standard_label,
+            documentation=documentation,
             type=XBRLType.from_arelle_type(concept.type),
-            period_type=concept.periodType,
+            # Arelle types `periodType` as a plain `str`, wider than our Literal --
+            # pydantic validates the actual value at construction time.
+            period_type=concept.periodType,  # ty:ignore[invalid-argument-type]
             child_concepts=[
                 Concept.from_list(concept, concept_dict) for concept in concept_list[3:]
             ],

--- a/src/ferc_xbrl_extractor/taxonomy.py
+++ b/src/ferc_xbrl_extractor/taxonomy.py
@@ -231,7 +231,7 @@ class Taxonomy(BaseModel):
         cls,
         taxonomy_source: Path | BinaryIO,
         entry_point: str | Path,
-    ):
+    ) -> "Taxonomy":
         """Construct taxonomy from taxonomy URL.
 
         Use Arelle to parse a taxonomy from a URL or local file path. The

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -141,7 +141,11 @@ def table_data_from_instances(
                 category=FutureWarning,
                 message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated",
             )
-            filings = {table: pd.concat(dfs) for table, dfs in results["dfs"].items()}
+            # Concatenating the (already-consolidated) per-batch frames re-fragments
+            # the result, same reasoning as the .copy() in process_batch below.
+            filings = {
+                table: pd.concat(dfs).copy() for table, dfs in results["dfs"].items()
+            }
         metadata = results["metadata"]
         return filings, metadata
 
@@ -186,7 +190,13 @@ def process_batch(
             category=FutureWarning,
             message="The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.",
         )
-        concatenated_dfs = {key: pd.concat(df_list) for key, df_list in dfs.items()}
+        # pd.concat of many single-filing frames leaves the result internally
+        # fragmented (one block per input frame); .copy() consolidates it into
+        # a single block per column so downstream ops (reset_index, merge,
+        # to_sql, ...) don't repeatedly trip pandas' PerformanceWarning.
+        concatenated_dfs = {
+            key: pd.concat(df_list).copy() for key, df_list in dfs.items()
+        }
 
     return {"dfs": concatenated_dfs, "metadata": metadata}
 

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import BinaryIO, TypedDict, cast
 from zipfile import ZipFile
 
-import numpy as np
 import pandas as pd
 from frictionless import Package
 from lxml.etree import XMLSyntaxError  # nosec: B410
@@ -91,6 +90,30 @@ def extract(
     return ExtractOutput(table_defs=table_defs, table_data=table_data, stats=stats)
 
 
+def _split_into_batches(
+    instance_builders: list[InstanceBuilder], num_batches: int
+) -> list[list[InstanceBuilder]]:
+    """Split instance_builders into num_batches parts of as-equal size as possible.
+
+    Sizes differ by at most one, with the first
+    ``len(instance_builders) % num_batches`` batches getting the extra item.
+    This matters because XBRL parsing is slow: fixed-size chunking (repeating
+    the same, already-floor-divided ``batch_size`` for every batch but the
+    last) can leave every other batch slower than necessary -- e.g. 25 items
+    with a target ``batch_size`` of 6 chunks as four batches of 6 plus a
+    straggling batch of 1, whereas this equal split gives five batches of 5,
+    cutting the slowest batch down and finishing the whole run sooner.
+    """
+    quotient, remainder = divmod(len(instance_builders), num_batches)
+    batches = []
+    start = 0
+    for i in range(num_batches):
+        stop = start + quotient + (1 if i < remainder else 0)
+        batches.append(instance_builders[start:stop])
+        start = stop
+    return batches
+
+
 def table_data_from_instances(
     instance_builders: list[InstanceBuilder],
     table_defs: dict[str, FactTable],
@@ -114,16 +137,13 @@ def table_data_from_instances(
         batch_size = num_instances // workers if workers else num_instances
 
     num_batches = math.ceil(num_instances / batch_size)
+    batched_instances = _split_into_batches(instance_builders, num_batches)
 
     with Executor(max_workers=workers) as executor:
         # Bind arguments generic to all filings
         process_batches = partial(
             process_batch,
             table_defs=table_defs,
-        )
-
-        batched_instances = np.array_split(
-            instance_builders, math.ceil(num_instances / batch_size)
         )
 
         # Use thread pool to extract data from all filings in parallel

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import BinaryIO, TypedDict, cast
 from zipfile import ZipFile
 
+import numpy as np
 import pandas as pd
 from frictionless import Package
 from lxml.etree import XMLSyntaxError  # nosec: B410
@@ -90,30 +91,6 @@ def extract(
     return ExtractOutput(table_defs=table_defs, table_data=table_data, stats=stats)
 
 
-def _split_into_batches(
-    instance_builders: list[InstanceBuilder], num_batches: int
-) -> list[list[InstanceBuilder]]:
-    """Split instance_builders into num_batches parts of as-equal size as possible.
-
-    Sizes differ by at most one, with the first
-    ``len(instance_builders) % num_batches`` batches getting the extra item.
-    This matters because XBRL parsing is slow: fixed-size chunking (repeating
-    the same, already-floor-divided ``batch_size`` for every batch but the
-    last) can leave every other batch slower than necessary -- e.g. 25 items
-    with a target ``batch_size`` of 6 chunks as four batches of 6 plus a
-    straggling batch of 1, whereas this equal split gives five batches of 5,
-    cutting the slowest batch down and finishing the whole run sooner.
-    """
-    quotient, remainder = divmod(len(instance_builders), num_batches)
-    batches = []
-    start = 0
-    for i in range(num_batches):
-        stop = start + quotient + (1 if i < remainder else 0)
-        batches.append(instance_builders[start:stop])
-        start = stop
-    return batches
-
-
 def table_data_from_instances(
     instance_builders: list[InstanceBuilder],
     table_defs: dict[str, FactTable],
@@ -137,13 +114,19 @@ def table_data_from_instances(
         batch_size = num_instances // workers if workers else num_instances
 
     num_batches = math.ceil(num_instances / batch_size)
-    batched_instances = _split_into_batches(instance_builders, num_batches)
 
     with Executor(max_workers=workers) as executor:
         # Bind arguments generic to all filings
         process_batches = partial(
             process_batch,
             table_defs=table_defs,
+        )
+
+        # numpy's stubs have no overload for splitting a plain list of arbitrary
+        # objects (only numeric arrays/arrays of a known dtype); it works fine at
+        # runtime, boxing instance_builders into an object array before splitting.
+        batched_instances = np.array_split(  # pyrefly: ignore[no-matching-overload]
+            instance_builders, num_batches
         )
 
         # Use thread pool to extract data from all filings in parallel

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -269,11 +269,13 @@ def get_fact_tables(
             logger = get_logger(__name__)
             logger.info(f"Parsing taxonomy from {taxonomy_version}")
             with taxonomy_archive.open(taxonomy_version, mode="r") as f:
-                taxonomy_date = re.search(
-                    r"\d{4}-\d{2}-\d{2}", taxonomy_version
-                ).group(  # pyrefly: ignore[missing-attribute] -- pre-existing gap
-                    0
-                )
+                match = re.search(r"\d{4}-\d{2}-\d{2}", taxonomy_version)
+                if match is None:
+                    raise ValueError(
+                        "Could not find a date (YYYY-MM-DD) in taxonomy "
+                        f"filename: {taxonomy_version}"
+                    )
+                taxonomy_date = match.group(0)
 
                 taxonomy_entry_point = f"taxonomy/form{form_number}/{taxonomy_date}/form/form{form_number}/form-{form_number}_{taxonomy_date}.xsd"
                 # ZipFile.open() is typed IO[bytes] in typeshed, but the ZipExtFile

--- a/src/ferc_xbrl_extractor/xbrl.py
+++ b/src/ferc_xbrl_extractor/xbrl.py
@@ -96,7 +96,7 @@ def table_data_from_instances(
     table_defs: dict[str, FactTable],
     batch_size: int | None = None,
     workers: int | None = None,
-) -> tuple[dict[str, pd.DataFrame], dict[str, list]]:
+) -> tuple[dict[str, pd.DataFrame], dict[str, dict]]:
     """Turn FactTables into Dataframes by ingesting facts from instances.
 
     To handle lots of instances, we split the instances into batches.
@@ -127,13 +127,14 @@ def table_data_from_instances(
         )
 
         # Use thread pool to extract data from all filings in parallel
-        results = {"dfs": defaultdict(list), "metadata": defaultdict(dict)}
+        dfs_by_table: defaultdict[str, list[pd.DataFrame]] = defaultdict(list)
+        metadata_by_filing: defaultdict[str, dict] = defaultdict(dict)
         for i, batch in enumerate(executor.map(process_batches, batched_instances)):
             logger.info(f"Finished batch {i + 1}/{num_batches}")
             for key, df in batch["dfs"].items():
-                results["dfs"][key].append(df)
+                dfs_by_table[key].append(df)
             for instance_name, fact_ids in batch["metadata"].items():
-                results["metadata"][instance_name] |= fact_ids
+                metadata_by_filing[instance_name] |= fact_ids
 
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -144,10 +145,9 @@ def table_data_from_instances(
             # Concatenating the (already-consolidated) per-batch frames re-fragments
             # the result, same reasoning as the .copy() in process_batch below.
             filings = {
-                table: pd.concat(dfs).copy() for table, dfs in results["dfs"].items()
+                table: pd.concat(dfs).copy() for table, dfs in dfs_by_table.items()
             }
-        metadata = results["metadata"]
-        return filings, metadata
+        return filings, metadata_by_filing
 
 
 def process_batch(
@@ -266,7 +266,9 @@ def get_fact_tables(
             logger = get_logger(__name__)
             logger.info(f"Parsing taxonomy from {taxonomy_version}")
             with taxonomy_archive.open(taxonomy_version, mode="r") as f:
-                taxonomy_date = re.search(r"\d{4}-\d{2}-\d{2}", taxonomy_version).group(
+                taxonomy_date = re.search(
+                    r"\d{4}-\d{2}-\d{2}", taxonomy_version
+                ).group(  # pyrefly: ignore[missing-attribute] -- pre-existing gap
                     0
                 )
 

--- a/tests/integration/console_scripts_test.py
+++ b/tests/integration/console_scripts_test.py
@@ -41,6 +41,21 @@ def _find_empty_tables(db_conn, tables: set[str]) -> list[str]:
     return empty_tables
 
 
+def test_find_empty_tables():
+    """_find_empty_tables() flags zero-row tables and leaves populated ones alone.
+
+    The real extraction tests below only ever assert that *no* table came back
+    empty, so this branch was never actually exercised -- a real (if
+    minimal) DuckDB connection here forces it, rather than mocking.
+    """
+    with duckdb.connect(":memory:") as conn:
+        conn.execute("CREATE TABLE populated (x INTEGER)")
+        conn.execute("INSERT INTO populated VALUES (1)")
+        conn.execute("CREATE TABLE empty (x INTEGER)")
+
+        assert _find_empty_tables(conn, {"populated", "empty"}) == ["empty"]
+
+
 def _get_sqlite_df(db_conn, table: str) -> pd.DataFrame:
     df = db_conn.table(table).df()
     return df.astype(

--- a/tests/unit/arelle_interface_test.py
+++ b/tests/unit/arelle_interface_test.py
@@ -5,6 +5,19 @@ import pytest
 import ferc_xbrl_extractor.arelle_interface as arelle_interface
 
 
+@pytest.mark.parametrize("max_retries", [0, -1])
+def test_taxonomy_view_rejects_non_positive_max_retries(max_retries):
+    """_taxonomy_view() rejects max_retries < 1 instead of looping zero times.
+
+    Regression test for a bug a stricter pyrefly preset caught: with
+    max_retries < 1, the retry loop's body -- the only place `taxonomy` gets
+    assigned -- would never run, so the code after the loop would crash with a
+    confusing UnboundLocalError instead of a clear error.
+    """
+    with pytest.raises(ValueError, match="max_retries must be at least 1"):
+        arelle_interface._taxonomy_view("fake_source", max_retries=max_retries)
+
+
 def test_taxonomy_view_retries_then_raises_after_max_retries(mocker):
     """_taxonomy_view() retries with exponential backoff, then re-raises.
 

--- a/tests/unit/datapackage_test.py
+++ b/tests/unit/datapackage_test.py
@@ -140,6 +140,8 @@ def test_columns_from_concepts(link_role, duration_column_names, instant_column_
     link_role = LinkRole(**link_role)
     duration_resource = Resource.from_link_role(link_role, "duration", "test_path")
     instant_resource = Resource.from_link_role(link_role, "instant", "test_path")
+    assert duration_resource is not None
+    assert instant_resource is not None
 
     # Verify column names are correct
     duration_columns = {field.name: field for field in duration_resource.schema_.fields}
@@ -148,13 +150,14 @@ def test_columns_from_concepts(link_role, duration_column_names, instant_column_
     assert duration_column_names == set(duration_columns.keys())
     assert instant_column_names == set(instant_columns.keys())
 
-    # Verify data types
-    assert duration_columns.get("duration_concept").type_ == "string"
-    assert duration_columns.get("duration_concept_int").type_ == "integer"
+    # Verify data types -- indexing (rather than .get()) so a missing key raises
+    # instead of silently comparing None, and so the type isn't Optional.
+    assert duration_columns["duration_concept"].type_ == "string"
+    assert duration_columns["duration_concept_int"].type_ == "integer"
 
-    assert instant_columns.get("instant_concept").type_ == "string"
-    assert instant_columns.get("child_concept").type_ == "year"
-    assert instant_columns.get("concept_bool").type_ == "boolean"
+    assert instant_columns["instant_concept"].type_ == "string"
+    assert instant_columns["child_concept"].type_ == "year"
+    assert instant_columns["concept_bool"].type_ == "boolean"
 
 
 def test_fuzzy_dedup():

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -37,7 +37,14 @@ def test_process_batch(mocker):
 
         def parse(self):
             if self.raise_exception:
-                raise XMLSyntaxError("message", 1, 0, 0)
+                # lxml's stub for XMLSyntaxError.__init__ only declares 2 of the 4
+                # positional args the real (C-implemented) constructor accepts.
+                raise XMLSyntaxError(
+                    "message",
+                    1,
+                    0,
+                    0,
+                )
             return self
 
     test_data = {

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -1,7 +1,32 @@
+import io
+import zipfile
+
 import pandas as pd
+import pytest
 from lxml.etree import XMLSyntaxError  # nosec: B410
 
-from ferc_xbrl_extractor.xbrl import process_batch, process_instance
+from ferc_xbrl_extractor.xbrl import get_fact_tables, process_batch, process_instance
+
+
+def test_get_fact_tables_rejects_undated_taxonomy_filename():
+    """get_fact_tables() raises a clear error if a taxonomy filename has no date.
+
+    taxonomy_date is parsed out of each zip member's name via regex before the
+    member's contents are ever touched, so this doesn't need a real taxonomy --
+    just a zip archive with a member name that doesn't match the expected
+    YYYY-MM-DD pattern.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("taxonomy/form1/no-date-here/form-1.xsd", "")
+    buf.seek(0)
+
+    with pytest.raises(ValueError, match="Could not find a date"):
+        get_fact_tables(
+            taxonomy_source=buf,
+            form_number=1,
+            db_uri="sqlite:///test.sqlite",
+        )
 
 
 def test_process_instance(mocker):

--- a/tests/unit/xbrl_test.py
+++ b/tests/unit/xbrl_test.py
@@ -83,7 +83,7 @@ def test_process_batch(mocker):
     # stand-ins: process_instance is mocked out below, so neither argument's real
     # structure is ever exercised, and building real InstanceBuilder/FactTable
     # fixtures here wouldn't test anything more.
-    results = process_batch(instances, table_defs)  # ty:ignore[invalid-argument-type]
+    results = process_batch(instances, table_defs)  # pyrefly: ignore[bad-argument-type]
 
     for table in table_defs:
         pd.testing.assert_frame_equal(


### PR DESCRIPTION
# Overview

Closes #443

`ty` found ~30 type errors in #444, mostly tracing back to Arelle and (I thought) `frictionless`, which I suppressed with `# ty:ignore` comments pending this follow-up. The plan there was a local type stub package for both libraries. But investigating the errors more deeply it turned out almost none of them really actually needed stubs. See #443 for the full reasoning; the short version:

- `ty` already reads Arelle's inline types directly despite it shipping no `py.typed` marker, so most of the `arelle`-related ignores were just missing `None` type narrowing, not missing type information.
- The `frictionless`-labeled ignores didn't involve the `frictionless` library at all -- they were on first-party pydantic models that happen to share names with it.
- The couple of ignores that *are* genuine gaps (a static type too generic for how we actually use the value at runtime) can be handled as one-offs.

## Fully typed, switched from ty to pyrefly

- #444 This got the package up to 85% typing coverage so I decided to go for it, and see what fully typing the package would entail to learn more about the tools and process.
- I found that `pyrefly` really is more mature and full featured, and there wasn't a long way to go to get the type annotations working with its `default` preset.
- One really nice thing it does is provide a typing coverage report and allow you to check whether the typing coverage meets a given threshold.
- It may not be quite as fast as `ty` but it's plenty fast.

As a result of all that I:

- Switched from `ty` to `pyrefly` as the type checker and set it up to run in (local) pre-commit and (GitHub) CI.
- Switched to a modern, maintained lxml type stub package (which caught some deprecated stuff in our code)
- Added a pixi task that outputs a human-readable typing summary coverage (with a little script that reformats the JSON that pyrefly generates)
- Addressed all of the typing issues it brought up at the `default` strictness, and got it to 100% typing coverage.
- Set the required threshold to 95% typing coverage.
- Added a `py.typed` file to the package.

## Testing

Run these commands to do all the checking:

```console
hatch run lint:all
hatch run types:check
hatch run types:coverage-check
hatch run types:coverage-report
hatch run docs:check
hatch run test:all
```

## To-do list

- [x] Self-review the diff for the line-by-line specifics
